### PR TITLE
Ravel.reflect()

### DIFF
--- a/lib/core/decorators/inject.js
+++ b/lib/core/decorators/inject.js
@@ -29,8 +29,8 @@ const inject = function(...rest) {
         throw new ApplicationError.IllegalValue('Values supplied to @inject decorator must be strings.');
       }
     }
-    Metadata.putClassMeta(target, '@inject', 'dependencies',
-      rest.concat(Metadata.getClassMetaValue(target, '@inject', 'dependencies', [])));
+    Metadata.putClassMeta(target.prototype, '@inject', 'dependencies',
+      rest.concat(Metadata.getClassMetaValue(target.prototype, '@inject', 'dependencies', [])));
   };
 };
 

--- a/lib/core/decorators/mapping.js
+++ b/lib/core/decorators/mapping.js
@@ -4,16 +4,31 @@ const Metadata = require('../../util/meta');
 
 /**
  * Decorator for setting the relative path of a method within a Route
+ * @param {Symbol} verb an HTTP verb such as Routes.GET, Routes.POST, Routes.PUT, or Routes.DELETE
+ * @param {String} the path for this endpoint, relative to the base path of the Routes class
+ * @param {Number | undefined} a status to always return, if this is applied at the class-level. If applied at
+ *                             the method-level, then the method will be used as a handler instead.
  */
-function mapping(verb, path) {
+function mapping(verb, path, status) {
   return function(target, key, descriptor) {
-    const info = {
-      name: key,
-      verb: verb,
-      path: path,
-      endpoint: descriptor.value
-    };
-    Metadata.putClassMeta(target, '@mapping', key, info);
+    if (key === undefined) {
+      // class-level
+      path = path ? path : '/';
+      const info = {
+        verb: verb,
+        path: path,
+        status: status
+      };
+      Metadata.putClassMeta(target.prototype, '@mapping', verb.toString() + ' ' + path, info);
+    } else {
+      // method-level
+      const info = {
+        verb: verb,
+        path: path,
+        endpoint: descriptor.value
+      };
+      Metadata.putMethodMeta(target, key, '@mapping', 'info', info);
+    }
     // delete target[key];
   };
 }

--- a/lib/core/injector.js
+++ b/lib/core/injector.js
@@ -28,7 +28,7 @@ class Injector {
    *         target class.
    */
   getDependencies(DIClass) {
-    return Metadata.getClassMetaValue(DIClass, '@inject', 'dependencies', []);
+    return [].concat(Metadata.getClassMetaValue(DIClass.prototype, '@inject', 'dependencies', []));
   }
 
   /**

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -2,6 +2,7 @@
 
 const upath = require('upath');
 const symbols = require('./symbols');
+const Metadata = require('../util/meta');
 
 const sInit = Symbol('_init');
 
@@ -47,25 +48,29 @@ module.exports = function(Ravel) {
   Ravel.prototype.module = function(modulePath) {
     let name = upath.basename(modulePath, upath.extname(modulePath));
 
-    //if a module with this name has already been regsitered, error out
+    // if a module with this name has already been regsitered, error out
     if (this[symbols.moduleFactories][name]) {
       throw new this.ApplicationError.DuplicateEntry(
         'Module with name \'' + name + '\' has already been registered.');
     }
 
-    const moduleInject = require(upath.join(this.cwd, modulePath));
-    if (moduleInject.prototype instanceof Module) {
-      //build injection function
+    const moduleClass = require(upath.join(this.cwd, modulePath));
+    if (moduleClass.prototype instanceof Module) {
+      // store path to module file in metadata
+      Metadata.putClassMeta(moduleClass.prototype, 'source', 'path', modulePath);
+      // store known module with path as the key, so someone can reflect on the class
+      this[symbols.registerClassFunc](modulePath, moduleClass);
+      // build injection function
       this[symbols.moduleFactories][name] = () => {
-        //perform DI on module factory
-        const temp = this[symbols.injector].inject({},moduleInject);
+        // perform DI on module factory
+        const temp = this[symbols.injector].inject({},moduleClass);
         temp[sInit](this, name);
-        //overwrite uninitialized module with the correct one
+        // overwrite uninitialized module with the correct one
         this[symbols.modules][name] = temp;
         return temp;
       };
       this[symbols.moduleFactories][name].moduleName = name;
-      this[symbols.moduleFactories][name].dependencies = this[symbols.injector].getDependencies(moduleInject);
+      this[symbols.moduleFactories][name].dependencies = this[symbols.injector].getDependencies(moduleClass);
       this[symbols.moduleFactories][name].parents = [];
       this[symbols.moduleFactories][name].children = [];
     } else {
@@ -74,9 +79,9 @@ module.exports = function(Ravel) {
     }
 
 
-    //save uninitialized module to Ravel.modules
-    //temporarily, until it is replaced by an
-    //instantiated version in _moduleInit
+    // save uninitialized module to Ravel.modules
+    // temporarily, until it is replaced by an
+    // instantiated version in _moduleInit
     this[symbols.modules][name] = Object.create(null);
   };
 
@@ -90,28 +95,28 @@ module.exports = function(Ravel) {
   Ravel.prototype[symbols.moduleInit] = function() {
     const rootFactories = Object.create(null);
 
-    //build dependency graph
+    // build dependency graph
     for (let moduleName of Object.keys(this[symbols.moduleFactories])) {
       const dependencies = this[symbols.moduleFactories][moduleName].dependencies;
       const factoryDeps = [];
       for (let d=0;d<dependencies.length;d++) {
         if (this[symbols.moduleFactories][dependencies[d]] !== undefined) {
-          //build two-way edge
+          // build two-way edge
           factoryDeps.push(this[symbols.moduleFactories][dependencies[d]]);
           this[symbols.moduleFactories][dependencies[d]].children.push(this[symbols.moduleFactories][moduleName]);
         }
       }
       this[symbols.moduleFactories][moduleName].parents = factoryDeps;
 
-      //If this module has no dependencies on other client module factories,
-      //then it is a root node.
+      // If this module has no dependencies on other client module factories,
+      // then it is a root node.
       if (this[symbols.moduleFactories][moduleName].parents.length === 0) {
         this[symbols.moduleFactories][moduleName].maxDepth = 0;
         rootFactories[moduleName] = this[symbols.moduleFactories][moduleName];
       }
     }
 
-    //calculate max depth of each factory, then sort by it. detect cyclical dependencies.
+    // calculate max depth of each factory, then sort by it. detect cyclical dependencies.
     const instantiationOrder = [];
     const visitedMeta = new WeakMap();
     const calcDepth = (moduleFactory, visitedTag, startModule, last) => {
@@ -146,7 +151,7 @@ module.exports = function(Ravel) {
       instantiationOrder[depth].push(this[symbols.moduleFactories][moduleName]);
     }
 
-    //instantiate in depth order
+    // instantiate in depth order
     for (let currDepth=0;currDepth<instantiationOrder.length;currDepth++) {
       for (let m=0;m<instantiationOrder[currDepth].length;m++) {
         instantiationOrder[currDepth][m]();

--- a/lib/core/reflect.js
+++ b/lib/core/reflect.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const symbols = require('./symbols');
+const Metadata = require('../util/meta');
+const ApplicationError = require('../util/application_error');
+
+/**
+ * A container class for Metadata about Modules,
+ * Resources and Routes
+ */
+class Meta {
+  /**
+   * @param {String} path the file path of the target class, relative to the cwd
+   * @param {Function} klass the target class
+   */
+  constructor(path, klass) {
+    this.path = path;
+    this.class = klass;
+    this.registeredAt = Date.now();
+  }
+
+  /**
+   * @return {Object} the metadata for the target class
+   */
+  get metadata() {
+    return Metadata.getMeta(this.class.prototype);
+  }
+}
+
+/**
+ * Provides Ravel with a simple mechanism of reflecting
+ * on known classes which have been registered as
+ * modules, resources or routes.
+ */
+module.exports = function(Ravel) {
+
+  Ravel.prototype[symbols.registerClassFunc] = function(path, klass) {
+    this[symbols.knownClasses][path] = new Meta(path, klass);
+  };
+
+  /**
+   * Reflect on a module, resource or routes class which
+   * has been registered with Ravel, using its path as
+   * a key.
+   * @param {String} filePath the path to the file
+   * @return {Object} an object with useful reflection functions
+   */
+  Ravel.prototype.reflect = function(filePath) {
+    if (!this[symbols.knownClasses][filePath]) {
+      throw new ApplicationError.NotFound(
+        `Class at ${filePath} is not registered with Ravel.`);
+    } else {
+      return this[symbols.knownClasses][filePath];
+    }
+  };
+};

--- a/lib/core/resource.js
+++ b/lib/core/resource.js
@@ -3,6 +3,7 @@
 const upath = require('upath');
 const httpCodes = require('../util/http_codes');
 const symbols = require('./symbols');
+const Metadata = require('../util/meta');
 const Routes = require('./routes').Routes;
 const mapping = Routes.mapping;
 
@@ -21,14 +22,14 @@ const buildRoute = function(ravelInstance, resource, methodType, methodName) {
     mapping(methodType, subpath)(
       Object.getPrototypeOf(resource),
       methodName,
-      {value: resource[methodName].bind(resource)
-    });
+      {
+        value: resource[methodName].bind(resource)
+      }
+    );
   } else {
     //resource.log.info('Registering unimplemented resource endpoint ' + methodType.toUpperCase() + ' ' + bp);
     // add a fake handler which returns NOT_IMPLEMENTED
-    mapping(methodType, subpath)(Object.getPrototypeOf(resource), methodName, {value: function(ctx) {
-      ctx.status = httpCodes.NOT_IMPLEMENTED;
-    }});
+    mapping(methodType, subpath, httpCodes.NOT_IMPLEMENTED)(Object.getPrototypeOf(resource).constructor, undefined);
   }
 };
 
@@ -49,7 +50,6 @@ class Resource extends Routes {
 }
 Resource.prototype[sInit] = function(ravelInstance, koaRouter) {
   this.transaction = ravelInstance.db.middleware;
-
   // decorate methods with @mapping before handing off to Routes init
   buildRoute(ravelInstance, this, Routes.GET, 'getAll');
   buildRoute(ravelInstance, this, Routes.PUT, 'putAll');
@@ -84,12 +84,16 @@ module.exports = function(Ravel) {
 
     const resourceClass = require(upath.join(this.cwd, resourcePath));
     if (resourceClass.prototype instanceof Resource) {
-      //build resource instantiation function, which takes the
-      //current koa app as an argument
+      // store path to resource file in metadata
+      Metadata.putClassMeta(resourceClass.prototype, 'source', 'path', resourcePath);
+      // store known resource with path as the key, so someone can reflect on the class
+      this[symbols.registerClassFunc](resourcePath, resourceClass);
+      // build resource instantiation function, which takes the
+      // current koa app as an argument
       this[symbols.resourceFactories][resourcePath] = (koaRouter) => {
-          const resource = this[symbols.injector].inject({}, resourceClass);
-          resource[sInit](this, koaRouter);
-          return resource;
+        const resource = this[symbols.injector].inject({}, resourceClass);
+        resource[sInit](this, koaRouter);
+        return resource;
       };
     } else {
       throw new this.ApplicationError.IllegalValue(

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -4,6 +4,7 @@ const upath = require('upath');
 const symbols = require('./symbols');
 const Metadata = require('../util/meta');
 const ApplicationError = require('../util/application_error');
+const httpCodes = require('../util/http_codes');
 
 // Allows us to detect duplicate binds
 const endpoints = new Map();
@@ -15,7 +16,7 @@ const PUT = Symbol.for('put');
 const DELETE = Symbol.for('delete');
 
 // process all methods and add to koa app
-const buildRoute = function(ravelInstance, routes, koaRouter, meta) {
+const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) {
   const fullPath = upath.join(routes.basePath, meta.path);
 
   let verb;
@@ -41,10 +42,10 @@ const buildRoute = function(ravelInstance, routes, koaRouter, meta) {
   const middleware = [];
 
   //apply class-level @before middleware, if any
-  let toInject = Metadata.getClassMetaValue(routes, '@before', 'middleware', []);
+  let toInject = [].concat(Metadata.getClassMetaValue(routes, '@before', 'middleware', []));
 
   //then method-level @before middleware, if any
-  toInject = toInject.concat(Metadata.getMethodMetaValue(routes, meta.name, '@before', 'middleware', []));
+  toInject = toInject.concat(Metadata.getMethodMetaValue(routes, methodName, '@before', 'middleware', []));
 
   for (let i=0; i<toInject.length; i++) {
     const m = toInject[i];
@@ -52,14 +53,21 @@ const buildRoute = function(ravelInstance, routes, koaRouter, meta) {
   }
 
   //finally push actual function methodName, but wrap it with a generator
-  middleware.push(function*(next) {
-    const result = meta.endpoint(this);
-    // yield promises, so that exceptions can be caught properly
-    if (result instanceof Promise) {
-      yield result;
-    }
-    yield next;
-  });
+  if (meta.endpoint) {
+    middleware.push(function*(next) {
+      const result = meta.endpoint(this);
+      // yield promises, so that exceptions can be caught properly
+      if (result instanceof Promise) {
+        yield result;
+      }
+      yield next;
+    });
+  } else {
+    middleware.push(function*(next) {
+      this.status = meta.status ? meta.status : httpCodes.NOT_IMPLEMENTED;
+      yield next;
+    });
+  }
 
   args = args.concat(middleware);
   // now call underlying koa method to register middleware at specific route
@@ -109,10 +117,21 @@ Routes.prototype[symbols.routesInitFunc] = function(ravelInstance, koaRouter, sh
     get: ravelInstance.get
   };
   const proto = Object.getPrototypeOf(this);
-  const meta = Metadata.getClassMeta(proto, '@mapping');
-  const methods = Object.keys(meta);
-  for (let r of methods) {
-    buildRoute(ravelInstance, this, koaRouter, meta[r], shouldLog);
+
+  // handle class-level @mapping decorators
+  const classMeta = Metadata.getClassMeta(proto, '@mapping', Object.create(null));
+  for (let r of Object.keys(classMeta)) {
+    buildRoute(ravelInstance, this, koaRouter, r, classMeta[r], shouldLog);
+  }
+
+  // handle methods decorated with @mapping
+  const meta = Metadata.getMeta(proto).method;
+  const annotatedMethods = Object.keys(meta);
+  for (let r of annotatedMethods) {
+    const methodMeta = Metadata.getMethodMetaValue(proto, r, '@mapping', 'info');
+    if (methodMeta) {
+      buildRoute(ravelInstance, this, koaRouter, r, methodMeta, shouldLog);
+    }
   }
 };
 
@@ -132,26 +151,31 @@ module.exports = function(Ravel) {
    * with Ravel which will be available, by name, at the given
    * base path.
    *
-   * @param {String} directoryModulePath the path of the directory module to require(...)
+   * @param {String} routesModulePath the path of the routes module to require(...)
    */
-  Ravel.prototype.routes = function(routeModulePath) {
+  Ravel.prototype.routes = function(routesModulePath) {
     //if a module with this name has already been regsitered, error out
-    if (this[symbols.routesFactories][routeModulePath]) {
+    if (this[symbols.routesFactories][routesModulePath]) {
       throw new this.ApplicationError.DuplicateEntry(
-        `Route module \'${routeModulePath}\' has already been registered.`);
+        `Route module \'${routesModulePath}\' has already been registered.`);
     }
 
-    const routesClass = require(upath.join(this.cwd, routeModulePath));
+    const routesClass = require(upath.join(this.cwd, routesModulePath));
     if (routesClass.prototype instanceof Routes) {
-      //This will be run in Ravel.start
-      this[symbols.routesFactories][routeModulePath] = (koaRouter) => {
-          const routes = this[symbols.injector].inject({}, routesClass);
-          routes[symbols.routesInitFunc](this, koaRouter);
-          return routes;
+      //store path to module file in metadata
+      Metadata.putClassMeta(routesClass.prototype, 'source', 'path', routesModulePath);
+      // store known routes module with path as the key, so someone can reflect on the class
+      this[symbols.registerClassFunc](routesModulePath, routesClass);
+      //build routes instantiation function, which takes the
+      //current koa app as an argument
+      this[symbols.routesFactories][routesModulePath] = (koaRouter) => {
+        const routes = this[symbols.injector].inject({}, routesClass);
+        routes[symbols.routesInitFunc](this, koaRouter);
+        return routes;
       };
     } else {
       throw new this.ApplicationError.IllegalValue(
-        `Routes Module with path ${routeModulePath} must be a subclass of Ravel.Routes`);
+        `Routes Module with path ${routesModulePath} must be a subclass of Ravel.Routes`);
     }
   };
 

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -11,6 +11,7 @@ module.exports = class {
   static get moduleFactories() { return Symbol.for('_moduleFactories'); }
   static get resourceFactories() { return Symbol.for('_resourceFactories'); }
   static get routesFactories() { return Symbol.for('_routesFactories'); }
+  static get knownClasses() { return Symbol.for('_knownClasses'); }
 
   // methods
   static get loadParameters() { return Symbol.for('_loadParameters()'); }
@@ -18,6 +19,7 @@ module.exports = class {
   static get resourceInit() { return  Symbol.for('_resourceInit'); }
   static get routesInit() { return  Symbol.for('_routesInit'); }
   static get routesInitFunc() { return Symbol.for('_routesInitFunc'); }
+  static get registerClassFunc() { return Symbol.for('_registerClassFunc'); }
 
   // objects
   static get injector() { return Symbol.for('Injector'); }

--- a/lib/ravel.js
+++ b/lib/ravel.js
@@ -23,6 +23,7 @@ class Ravel extends EventEmitter {
     this[sInitialized] = false;
     this[sListening] = false;
 
+    // how we store modules for dependency injection
     this[coreSymbols.modules] = Object.create(null);
 
     // current working directory of the app using the
@@ -36,6 +37,8 @@ class Ravel extends EventEmitter {
     this[coreSymbols.moduleFactories] = Object.create(null);
     this[coreSymbols.resourceFactories] = Object.create(null);
     this[coreSymbols.routesFactories] = Object.create(null);
+    // a list of known modules, resources and routes so that metadata can be retrieved from them
+    this[coreSymbols.knownClasses] = Object.create(null);
 
     // init errors
     this.ApplicationError = require('./util/application_error');
@@ -219,7 +222,7 @@ class Ravel extends EventEmitter {
    */
   close() {
     return new Promise((resolve) => {
-      console.log('closing');
+      // console.log('closing');
       if (!this.server || !this[sListening]) {
         resolve();
       } else {
@@ -272,5 +275,8 @@ require('./core/resource')(Ravel);
 
 // init recursive resource registration (Ravel.resources)
 require('./core/resources')(Ravel);
+
+// init reflection (Ravel.reflect)
+require('./core/reflect')(Ravel);
 
 module.exports = Ravel;

--- a/lib/util/meta.js
+++ b/lib/util/meta.js
@@ -1,6 +1,14 @@
 'use strict';
 
+const ApplicationError = require('../util/application_error');
+
 const sMeta = Symbol.for('_metadata');
+
+function isPrototype(target) {
+  if (!(typeof target === 'object') || !target.constructor) {
+    throw new ApplicationError.IllegalValue('Must get and set metadata on a class prototype.');
+  }
+}
 
 /**
  * Facilitates accessing andstoring metadata, generally
@@ -13,6 +21,7 @@ module.exports = class Metadata {
    * @return {Object} the metadata object for the given class
    */
   static getMeta(target) {
+    isPrototype(target);
     if (typeof target[sMeta] !== 'object') {
       target[sMeta] = Object.create(null);
       target[sMeta].class = Object.create(null);
@@ -25,14 +34,13 @@ module.exports = class Metadata {
    * Gets the class-level metadata for a class
    * @param target {Class} a class
    * @param category {String} a category
+   * @param defaultValue {Any | undefined} return this value if the given category does not exist
    * @return {Object} the class-level metadata object for the given class
    */
-  static getClassMeta(target, category) {
+  static getClassMeta(target, category, defaultValue) {
+    isPrototype(target);
     const classMeta = Metadata.getMeta(target).class;
-    if (typeof classMeta[category] !== 'object') {
-      classMeta[category] = Object.create(null);
-    }
-    return classMeta[category];
+    return classMeta[category] ? classMeta[category] : defaultValue;
   }
 
   /**
@@ -44,8 +52,9 @@ module.exports = class Metadata {
    * @return {Object} the class-level metadata object for the given class
    */
   static getClassMetaValue(target, category, key, defaultValue) {
+    isPrototype(target);
     const classMeta = Metadata.getClassMeta(target, category);
-    return classMeta[key] ? classMeta[key] : defaultValue;
+    return classMeta && classMeta[key] ? classMeta[key] : defaultValue;
   }
 
   /**
@@ -53,17 +62,14 @@ module.exports = class Metadata {
    * @param target {Class} a class
    * @param method {String} the method name
    * @param category {String} a category
+   * @param defaultValue {Any | undefined} return this value if the given category does not exist
    * @return {Object} the class-level metadata object for the given class
    */
-  static getMethodMeta(target, method, category) {
+  static getMethodMeta(target, method, category, defaultValue) {
+    isPrototype(target);
     const methodMeta = Metadata.getMeta(target).method;
-    if (typeof methodMeta[method] !== 'object') {
-      methodMeta[method] = Object.create(null);
-    }
-    if (typeof methodMeta[method][category] !== 'object') {
-      methodMeta[method][category] = Object.create(null);
-    }
-    return methodMeta[method][category];
+    return methodMeta[method] ?
+      methodMeta[method][category] ? methodMeta[method][category] : defaultValue : defaultValue;
   }
 
   /**
@@ -76,8 +82,9 @@ module.exports = class Metadata {
    * @return {Object} the class-level metadata object for the given class
    */
   static getMethodMetaValue(target, method, category, key, defaultValue) {
+    isPrototype(target);
     const methodMeta = Metadata.getMethodMeta(target, method, category);
-    return methodMeta[key] ? methodMeta[key] : defaultValue;
+    return methodMeta && methodMeta[key] ? methodMeta[key] : defaultValue;
   }
 
   /**
@@ -88,8 +95,12 @@ module.exports = class Metadata {
    * @param value {Any} the value to set at the given key
    */
   static putClassMeta(target, category, key, value) {
-    const catMap = Metadata.getClassMeta(target, category);
-    catMap[key] = value;
+    isPrototype(target);
+    const classMeta = Metadata.getMeta(target).class;
+    if (typeof classMeta[category] !== 'object') {
+      classMeta[category] = Object.create(null);
+    }
+    classMeta[category][key] = value;
   }
 
   /**
@@ -101,7 +112,14 @@ module.exports = class Metadata {
    * @param value {Any} the value to set at the given key
    */
   static putMethodMeta(target, method, category, key, value) {
-    const catMap = Metadata.getMethodMeta(target, method, category);
-    catMap[key] = value;
+    isPrototype(target);
+    const methodMeta = Metadata.getMeta(target).method;
+    if (typeof methodMeta[method] !== 'object') {
+      methodMeta[method] = Object.create(null);
+    }
+    if (typeof methodMeta[method][category] !== 'object') {
+      methodMeta[method][category] = Object.create(null);
+    }
+    methodMeta[method][category][key] = value;
   }
 };

--- a/test/core/decorators/test-inject.js
+++ b/test/core/decorators/test-inject.js
@@ -10,7 +10,6 @@ let inject;
 describe('Ravel', function() {
   beforeEach(function(done) {
     inject = require('../../../lib/ravel').inject;
-
     done();
   });
 
@@ -26,8 +25,8 @@ describe('Ravel', function() {
         constructor(test1, test2) { //eslint-disable-line no-unused-vars
         }
       }
-      expect(Metadata.getClassMetaValue(Stub1, '@inject', 'dependencies')).to.be.an.array;
-      expect(Metadata.getClassMetaValue(Stub1, '@inject', 'dependencies')).to.deep.equal(['test1', 'test2']);
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@inject', 'dependencies')).to.be.an.array;
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@inject', 'dependencies')).to.deep.equal(['test1', 'test2']);
       done();
     });
 
@@ -38,8 +37,8 @@ describe('Ravel', function() {
         constructor(test1, test2, test3) { //eslint-disable-line no-unused-vars
         }
       }
-      expect(Metadata.getClassMetaValue(Stub1, '@inject', 'dependencies')).to.be.an.array;
-      expect(Metadata.getClassMetaValue(Stub1, '@inject', 'dependencies')).to.deep.equal(['test1', 'test2', 'test3']);
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@inject', 'dependencies')).to.be.an.array;
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@inject', 'dependencies')).to.deep.equal(['test1', 'test2', 'test3']);
       done();
     });
 

--- a/test/core/test-reflect.js
+++ b/test/core/test-reflect.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('chai-things'));
+const mockery = require('mockery');
+chai.use(require('sinon-chai'));
+const upath = require('upath');
+
+const coreSymbols = require('../../lib/core/symbols');
+let Ravel, app;
+
+describe('Ravel', function() {
+  beforeEach(function(done) {
+    //enable mockery
+    mockery.enable({
+      useCleanCache: true,
+      warnOnReplace: false,
+      warnOnUnregistered: false
+    });
+
+    Ravel = require('../../lib/ravel');
+    app = new Ravel();
+    app.Log.setLevel(app.Log.NONE);
+    app.kvstore = {}; //mock Ravel.kvstore, since we're not actually starting Ravel.
+    done();
+  });
+
+  afterEach(function(done) {
+    Ravel = undefined;
+    app = undefined;
+    mockery.deregisterAll();
+    mockery.disable();
+    done();
+  });
+
+  describe('#reflect()', function() {
+    it('should allow clients to retrieve metadata from Modules', function(done) {
+      const inject = Ravel.inject;
+      const another = {};
+      mockery.registerMock('another', another);
+      @inject('another')
+      class Stub extends Ravel.Module {
+        constructor(a) {
+          super();
+          expect(a).to.equal(another);
+        }
+
+        method() {}
+      }
+      mockery.registerMock(upath.join(app.cwd, 'test'), Stub);
+      app.module('./test');
+
+      const meta = app.reflect('./test').metadata;
+      expect(meta).to.deep.equal({
+        class: {
+          '@inject': { dependencies: ['another'] },
+          source: { path: './test' }
+        },
+        method: {}
+      });
+      done();
+    });
+
+    it('should allow clients to retrieve metadata from Routes', function(done) {
+      const Routes = Ravel.Routes;
+      const before = Routes.before;
+      const mapping = Routes.mapping;
+
+      @before('middleware1')
+      @mapping(Routes.GET, '/path', 404)
+      class Stub extends Routes {
+        constructor() {
+          super('/app');
+        }
+
+        @mapping(Routes.PUT, '/path')
+        @before('middleware2')
+        pathHandler(ctx) {
+          ctx.status = 200;
+        }
+      };
+      mockery.registerMock(upath.join(app.cwd, './stub'), Stub);
+      app.routes('./stub');
+      const meta = app.reflect('./stub').metadata;
+      expect(meta).to.deep.equal({
+        class: {
+          '@before': { middleware: ['middleware1'] },
+          '@mapping': {
+            'Symbol(get) /path':{
+              path: '/path',
+              verb: Routes.GET,
+              status: 404
+            }
+          },
+          source: { path: './stub' }
+        },
+        method: {
+          pathHandler: {
+            '@before': { middleware: ['middleware2'] },
+            '@mapping':  {
+              info: {
+                endpoint: Stub.prototype.pathHandler,
+                path: '/path',
+                verb: Routes.PUT
+              }
+            }
+          }
+        }
+      });
+      done();
+    });
+
+    it('should allow clients to retrieve metadata from Resources', function(done) {
+      const middleware1 = function*(next) { yield next; };
+      const middleware2 = function*(next) { yield next; };
+      const Resource = Ravel.Resource;
+      const before = Resource.before;
+
+      @before('middleware1')
+      class Stub extends Resource {
+        constructor() {
+          super('/app');
+        }
+
+        @before('middleware2')
+        get(ctx) {
+          ctx.status = 200;
+        }
+      };
+      mockery.registerMock(upath.join(app.cwd, './stub'), Stub);
+      mockery.registerMock('middleware1', middleware1);
+      mockery.registerMock('middleware2', middleware2);
+      app.db = { // mock app.db
+        middleware: function*(next){ yield next;}
+      };
+      app.resource('./stub');
+
+      // need to call resource init so that it creates @mapping decorators
+      const router = require('koa-router')();
+      app[coreSymbols.resourceInit](router);
+
+      const meta = app.reflect('./stub').metadata;
+
+      expect(meta).to.deep.equal({
+        class: {
+          '@before': { middleware: ['middleware1'] },
+          '@mapping': {
+            'Symbol(get) /': { verb: Resource.GET, path: '/', status: 501 },
+            'Symbol(put) /': { verb: Resource.PUT, path: '/', status: 501 },
+            'Symbol(delete) /': { verb: Resource.DELETE, path: '/', status: 501 },
+            'Symbol(post) /': { verb: Resource.POST, path: '/', status: 501 },
+            'Symbol(put) /:id': { verb: Resource.PUT, path: '/:id', status: 501 },
+            'Symbol(delete) /:id': { verb: Resource.DELETE, path: '/:id', status: 501 },
+          },
+          source: { path: './stub' }
+        },
+        method: {
+          get: {
+            '@before': { middleware: ['middleware2'] },
+            '@mapping':  {
+              info: {
+                endpoint: meta.method.get['@mapping'].info.endpoint,
+                path: '/:id',
+                verb: Resource.GET
+              }
+            }
+          }
+        }
+      });
+      done();
+    });
+  });
+});

--- a/test/util/test-meta.js
+++ b/test/util/test-meta.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const mockery = require('mockery');
+
+let Metadata;
+
+describe('util/meta', function() {
+
+  beforeEach(function(done) {
+    //enable mockery
+    mockery.enable({
+      useCleanCache: true,
+      warnOnReplace: false,
+      warnOnUnregistered: false
+    });
+    Metadata = require('../../lib/util/meta');
+    done();
+  });
+
+  afterEach(function(done) {
+    mockery.deregisterAll();mockery.disable();
+    Metadata = undefined;
+    done();
+  });
+
+  describe('#getMeta', function() {
+    it('should support retrieving metadata from a class', function(done) {
+      class Test {}
+      expect(Metadata.getMeta(Test.prototype)).to.deep.equal({
+        class: {},
+        method: {}
+      });
+      done();
+    });
+
+    it('should throw an exception if the target class isn\'t a prototype', function(done) {
+      class Test {}
+      expect(function() {
+        return Metadata.getMeta(Test);
+      }).to.throw;
+      done();
+    });
+  });
+
+  describe('#getClassMeta', function() {
+    it('should support the retrieval of class-level metadata within a category', function(done) {
+      class Test{}
+      expect(Metadata.getClassMeta(Test.prototype, 'category')).to.be.undefined;
+      done();
+    });
+    it('should throw an exception if the target class isn\'t a prototype', function(done) {
+      class Test {}
+      expect(function() {
+        return Metadata.getClassMeta(Test, 'category');
+      }).to.throw;
+      done();
+    });
+  });
+
+  describe('#getClassMetaValue', function() {
+    it('should support the retrieval of a value from a category of class-level metadata', function(done) {
+      class Test{}
+      expect(Metadata.getClassMetaValue(Test.prototype, 'category', 'key')).to.be.undefined;
+      done();
+    });
+    it('should throw an exception if the target class isn\'t a prototype', function(done) {
+      class Test {}
+      expect(function() {
+        return Metadata.getClassMetaValue(Test, 'category', 'key');
+      }).to.throw;
+      done();
+    });
+  });
+
+  describe('#getMethodMeta', function() {
+    it('should support the retrieval of method-level metadata within a category', function(done) {
+      class Test{}
+      expect(Metadata.getMethodMeta(Test.prototype, 'methodName', 'category')).to.be.undefined;
+      done();
+    });
+    it('should throw an exception if the target class isn\'t a prototype', function(done) {
+      class Test {}
+      expect(function() {
+        return Metadata.getMethodMeta(Test, 'methodName', 'category');
+      }).to.throw;
+      done();
+    });
+  });
+
+  describe('#getMethodMetaValue', function() {
+    it('should support the retrieval of a value from a category of method-level metadata', function(done) {
+      class Test{}
+      expect(Metadata.getMethodMetaValue(Test.prototype, 'methodName', 'category', 'key')).to.be.undefined;
+      done();
+    });
+    it('should throw an exception if the target class isn\'t a prototype', function(done) {
+      class Test {}
+      expect(function() {
+        return Metadata.getMethodMetaValue(Test, 'methodName', 'category', 'key');
+      }).to.throw;
+      done();
+    });
+  });
+
+  describe('#putClassMeta', function() {
+    it('should support storing metdata at the class-level', function(done) {
+      class Test{}
+      Metadata.putClassMeta(Test.prototype, '@inject', 'mykey', 'myvalue');
+      expect(Metadata.getMeta(Test.prototype)).to.deep.equal({
+        class: {
+          '@inject': {
+            'mykey':  'myvalue'
+          }
+        },
+        method: {}
+      });
+      expect(Metadata.getClassMeta(Test.prototype, '@inject')).to.deep.equal({
+        'mykey': 'myvalue'
+      });
+      expect(Metadata.getClassMeta(Test.prototype, '@inject')).to.equal(
+        Metadata.getMeta(Test.prototype).class['@inject']
+      );
+      expect(Metadata.getClassMetaValue(Test.prototype, '@inject', 'mykey')).to.equal('myvalue');
+      expect(Metadata.getClassMetaValue(Test.prototype, '@inject', 'mykey')).to.equal(
+        Metadata.getMeta(Test.prototype).class['@inject'].mykey
+      );
+      done();
+    });
+
+    it('should throw an exception if the target class isn\'t a prototype', function(done) {
+      class Test {}
+      expect(function() {
+        return Metadata.putClassMeta(Test, '@inject', 'mykey', 'myvalue');
+      }).to.throw;
+      done();
+    });
+  });
+
+  describe('#putMethodMeta', function() {
+    it('should support storing metdata at the method-level', function(done) {
+      class Test{}
+      Metadata.putMethodMeta(Test.prototype, 'methodName', '@inject', 'mykey', 'myvalue');
+      expect(Metadata.getMeta(Test.prototype)).to.deep.equal({
+        class: {},
+        method: {
+          'methodName': {
+            '@inject': {
+              'mykey':  'myvalue'
+            }
+          }
+        }
+      });
+      expect(Metadata.getMethodMeta(Test.prototype, 'methodName', '@inject')).to.deep.equal({
+        'mykey': 'myvalue'
+      });
+      expect(Metadata.getMethodMeta(Test.prototype, 'methodName', '@inject')).to.equal(
+        Metadata.getMeta(Test.prototype).method.methodName['@inject']
+      );
+      expect(Metadata.getMethodMetaValue(Test.prototype, 'methodName', '@inject', 'mykey')).to.equal('myvalue');
+      expect(Metadata.getMethodMetaValue(Test.prototype, 'methodName', '@inject', 'mykey')).to.equal(
+        Metadata.getMeta(Test.prototype).method.methodName['@inject'].mykey
+      );
+      done();
+    });
+
+    it('should throw an exception if the target class isn\'t a prototype', function(done) {
+      class Test {}
+      expect(function() {
+        return Metadata.putMethodMeta(Test, 'methodName', '@inject', 'mykey', 'myvalue');
+      }).to.throw;
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Bringing some sanity to the metadata system, so that everything is stored in the class prototype. Adding Ravel.reflect() to get metadata from a class using its file path as the key.

Fixes #70 