### PR TITLE
Making ravel.params, ravel.db, ravel.ApplicationError, ravel.log, etc. available inside Module/Resource/Routes constructors

### DIFF
--- a/lib/core/decorators/lifecycle.js
+++ b/lib/core/decorators/lifecycle.js
@@ -16,7 +16,7 @@ module.exports = {
   postlisten: function(target, key, descriptor) {
     Metadata.putClassMeta(target, '@postlisten', key, descriptor.value);
   },
-  end: function(target, key, descriptor) {
-    Metadata.putClassMeta(target, '@end', key, descriptor.value);
+  preclose: function(target, key, descriptor) {
+    Metadata.putClassMeta(target, '@preclose', key, descriptor.value);
   }
 };

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -13,25 +13,83 @@ const sInit = Symbol.for('_init');
  * injector.js, with dependency injection
  */
 class Module {
+  /**
+   * Methods decorated with this lifecycle decorator will fire after Ravel.init()
+   */
   static get postinit() { return lifeycle.postinit; }
+
+  /**
+   * Methods decorated with this lifecycle decorator will fire at the beginning of Ravel.listen()
+   */
   static get prelisten() { return lifeycle.prelisten; }
+
+  /**
+   * Methods decorated with this lifecycle decorator will fire at the end of Ravel.listen()
+   */
   static get postlisten() { return lifeycle.postlisten; }
-  static get end() { return lifeycle.end; }
+
+  /**
+   * Methods decorated with this lifecycle decorator will fire at the beginning of Ravel.close()
+   */
+  static get preclose() { return lifeycle.preclose; }
+
+  /**
+   * Returns a reference to the ravel instance with which this Module is registered
+   */
+  get app() {
+    return Metadata.getClassMetaValue(Object.getPrototypeOf(this), 'ravel', 'instance');
+  }
+
+  /**
+   * @return {String} the injection name for this module
+   */
+  get name() { return Metadata.getClassMetaValue(Object.getPrototypeOf(this), 'source', 'name'); }
+
+  /**
+   * @return {Object} Ravel's pre-packaged error types.
+   */
+  get ApplicationError() {
+    return this.app.ApplicationError;
+  }
+
+  /**
+   * @return {Object} the logger for this module
+   */
+  get log() {
+    return this.app.log.getLogger(this.name);
+  }
+
+  /**
+   * @return {Object} the Ravel key-value store connection
+   */
+  get kvstore() {
+    return this.app.kvstore;
+  }
+
+  /**
+   * @return {Object} an Object with a get() method, which allows easy access to ravel.get()
+   */
+  get params() {
+    const ravelInstance = this.app;
+    return {
+      get: ravelInstance.get.bind(ravelInstance)
+    };
+  }
+
+  /**
+   * @return {Object} an Object with a scoped() method, which allows easy access to ravel.db.scoped()
+   */
+  get db() {
+    const ravelInstance = this.app;
+    return {
+      scoped: function(gen) {
+        return ravelInstance.db.scoped.bind(ravelInstance.db)(gen);
+      }
+    };
+  }
 }
-Module.prototype[sInit] = function(ravelInstance, name) {
-  // set up basic stuff that all modules have access to
-  this.name = name;
-  this.ApplicationError = ravelInstance.ApplicationError;
-  this.log = ravelInstance.Log.getLogger(name);
-  this.kvstore = ravelInstance.kvstore;
-  this.params = {
-    get: ravelInstance.get.bind(ravelInstance)
-  };
-  this.db = {
-    scoped: function(gen) {
-      return ravelInstance.db.scoped.bind(ravelInstance.db)(gen);
-    }
-  };
+
+Module.prototype[sInit] = function(ravelInstance) {
   // connect any Ravel lifecycle handlers to the appropriate events
   const self = this;
   function connectHandlers(decorator, event) {
@@ -43,7 +101,7 @@ Module.prototype[sInit] = function(ravelInstance, name) {
   connectHandlers('@postinit', 'post init');
   connectHandlers('@prelisten', 'pre listen');
   connectHandlers('@postlisten', 'post listen');
-  connectHandlers('@end', 'end');
+  connectHandlers('@preclose', 'end');
 };
 
 /** add in @authconfig decorator as static property */
@@ -81,6 +139,10 @@ module.exports = function(Ravel) {
 
     const moduleClass = require(upath.join(this.cwd, modulePath));
     if (moduleClass.prototype instanceof Module) {
+      // store reference to this ravel instance in metadata
+      Metadata.putClassMeta(moduleClass.prototype, 'ravel', 'instance', this);
+      // store name in metadata
+      Metadata.putClassMeta(moduleClass.prototype, 'source', 'name', name);
       // store path to module file in metadata
       Metadata.putClassMeta(moduleClass.prototype, 'source', 'path', modulePath);
       // store known module with path as the key, so someone can reflect on the class
@@ -89,7 +151,7 @@ module.exports = function(Ravel) {
       this[symbols.moduleFactories][name] = () => {
         // perform DI on module factory
         const temp = this[symbols.injector].inject({},moduleClass);
-        temp[sInit](this, name);
+        temp[sInit](this);
         // overwrite uninitialized module with the correct one
         this[symbols.modules][name] = temp;
         return temp;

--- a/lib/core/resource.js
+++ b/lib/core/resource.js
@@ -84,6 +84,7 @@ module.exports = function(Ravel) {
 
     const resourceClass = require(upath.join(this.cwd, resourcePath));
     if (resourceClass.prototype instanceof Resource) {
+      Metadata.putClassMeta(resourceClass.prototype, 'ravel', 'instance', this);
       // store path to resource file in metadata
       Metadata.putClassMeta(resourceClass.prototype, 'source', 'path', resourcePath);
       // store known resource with path as the key, so someone can reflect on the class

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -85,9 +85,24 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
  */
 class Routes {
 
+  /**
+   * Used with the @mapping decorator to indicate the GET HTTP verb
+   */
   static get GET() { return GET; }
+
+  /**
+   * Used with the @mapping decorator to indicate the POST HTTP verb
+   */
   static get POST() { return POST; }
+
+  /**
+   * Used with the @mapping decorator to indicate the PUT HTTP verb
+   */
   static get PUT() { return PUT; }
+
+  /**
+   * Used with the @mapping decorator to indicate the DELETE HTTP verb
+   */
   static get DELETE() { return DELETE; }
 
   // It's expected that subclasses will call super(basePath)
@@ -107,19 +122,74 @@ class Routes {
       endpoints.set(bp, true);
     }
   }
+
+  /**
+   * Returns a reference to the ravel instance with which this Module is registered
+   */
+  get app() {
+    return Metadata.getClassMetaValue(Object.getPrototypeOf(this), 'ravel', 'instance');
+  }
+
+  /**
+   * @return {Object} Ravel's pre-packaged error types.
+   */
+  get ApplicationError() {
+    return this.app.ApplicationError;
+  }
+
+  /**
+   * @return {Object} the logger for this module
+   */
+  get log() {
+    return this.app.log.getLogger(this.name);
+  }
+
+  /**
+   * @return {Object} the Ravel key-value store connection
+   */
+  get kvstore() {
+    return this.app.kvstore;
+  }
+
+  /**
+   * @return {Object} an Object with a get() method, which allows easy access to ravel.get()
+   */
+  get params() {
+    const ravelInstance = this.app;
+    return {
+      get: ravelInstance.get.bind(ravelInstance)
+    };
+  }
+
+  /**
+   * Middleware for simple error handling and automatically selecting HTTP response codes.
+   * Intended to be used with the @before decorator.
+   */
+  get respond() {
+    return new (require('../util/rest'))(this.app).respond();
+  }
+
+  /**
+   * Middleware for limiting a route to only an authorized clients. Will respond with 401 if
+   * the calling client does not have an authorized session.
+   * Intended to be used with the @before decorator.
+   */
+  get authorize() {
+    return new (require('../auth/authorize_request'))(this.app, false, false).middleware();
+  }
+
+  /**
+   * Middleware for limiting a route to only an authorized clients. Will respond with 401 if
+   * the calling client does not have an authorized session, and redirect to the login page
+   * specified by Ravel.set('login route').
+   * Intended to be used with the @before decorator.
+   */
+  get authorizeRedirect() {
+    return new (require('../auth/authorize_request'))(this.app, true, false).middleware();
+  }
 }
 Routes.prototype[symbols.routesInitFunc] = function(ravelInstance, koaRouter, shouldLog) {
-  this.respond = new (require('../util/rest'))(ravelInstance).respond();
-  this.log = ravelInstance.Log.getLogger(this.constructor.name);
-  this.ApplicationError = ravelInstance.ApplicationError;
-  this.kvstore = ravelInstance.kvstore;
-  this.params = {
-    get: ravelInstance.get.bind(ravelInstance)
-  };
-  this.authorize = new (require('../auth/authorize_request'))(ravelInstance, false, false).middleware();
-  this.authorizeRedirect = new (require('../auth/authorize_request'))(ravelInstance, true, false).middleware();
   const proto = Object.getPrototypeOf(this);
-
   // handle class-level @mapping decorators
   const classMeta = Metadata.getClassMeta(proto, '@mapping', Object.create(null));
   for (let r of Object.keys(classMeta)) {
@@ -164,6 +234,8 @@ module.exports = function(Ravel) {
 
     const routesClass = require(upath.join(this.cwd, routesModulePath));
     if (routesClass.prototype instanceof Routes) {
+      // store reference to this ravel instance in metadata
+      Metadata.putClassMeta(routesClass.prototype, 'ravel', 'instance', this);
       //store path to module file in metadata
       Metadata.putClassMeta(routesClass.prototype, 'source', 'path', routesModulePath);
       // store known routes module with path as the key, so someone can reflect on the class

--- a/test/core/test-module.js
+++ b/test/core/test-module.js
@@ -86,6 +86,11 @@ describe('Ravel', function() {
     });
 
     it('should produce a module factory which can be used to instantiate the specified module and perform dependency injection', function(done) {
+      const scopedStub = sinon.stub();
+      Ravel.db = {
+        scoped: scopedStub
+      };
+
       const another = {};
       mockery.registerMock('another', another);
       @inject('another')
@@ -93,6 +98,22 @@ describe('Ravel', function() {
         constructor(a) {
           super();
           expect(a).to.equal(another);
+          expect(this.log).to.be.ok;
+          expect(this.log).to.be.an('object');
+          expect(this.log).to.have.property('trace').that.is.a('function');
+          expect(this.log).to.have.property('verbose').that.is.a('function');
+          expect(this.log).to.have.property('debug').that.is.a('function');
+          expect(this.log).to.have.property('info').that.is.a('function');
+          expect(this.log).to.have.property('warn').that.is.a('function');
+          expect(this.log).to.have.property('error').that.is.a('function');
+          expect(this.log).to.have.property('critical').that.is.a('function');
+          expect(this.ApplicationError).to.equal(Ravel.ApplicationError);
+          expect(this.kvstore).to.equal(Ravel.kvstore);
+          expect(this.params).to.be.an.object;
+          expect(this.params).to.have.a.property('get').that.is.a.function;
+          expect(this.db).to.have.a.property('scoped').that.is.an.function;
+          this.db.scoped();
+          expect(scopedStub).to.have.been.called;
         }
 
         method() {}
@@ -100,27 +121,6 @@ describe('Ravel', function() {
       mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
       Ravel.module('./test', 'test');
       Ravel[coreSymbols.moduleInit]();
-      const scopedStub = sinon.stub();
-      Ravel.db = {
-        scoped: scopedStub
-      };
-      const instance = Ravel[coreSymbols.modules].test;
-      expect(instance.log).to.be.ok;
-      expect(instance.log).to.be.an('object');
-      expect(instance.log).to.have.property('trace').that.is.a('function');
-      expect(instance.log).to.have.property('verbose').that.is.a('function');
-      expect(instance.log).to.have.property('debug').that.is.a('function');
-      expect(instance.log).to.have.property('info').that.is.a('function');
-      expect(instance.log).to.have.property('warn').that.is.a('function');
-      expect(instance.log).to.have.property('error').that.is.a('function');
-      expect(instance.log).to.have.property('critical').that.is.a('function');
-      expect(instance.ApplicationError).to.equal(Ravel.ApplicationError);
-      expect(instance.kvstore).to.equal(Ravel.kvstore);
-      expect(instance.params).to.be.an.object;
-      expect(instance.params).to.have.a.property('get').that.is.a.function;
-      expect(instance.db).to.have.a.property('scoped').that.is.an.function;
-      instance.db.scoped();
-      expect(scopedStub).to.have.been.called;
       done();
     });
 

--- a/test/core/test-reflect.js
+++ b/test/core/test-reflect.js
@@ -53,8 +53,9 @@ describe('Ravel', function() {
       const meta = app.reflect('./test').metadata;
       expect(meta).to.deep.equal({
         class: {
+          'ravel': {'instance': app },
           '@inject': { dependencies: ['another'] },
-          source: { path: './test' }
+          source: { 'name': 'test', path: './test' }
         },
         method: {}
       });
@@ -84,6 +85,7 @@ describe('Ravel', function() {
       const meta = app.reflect('./stub').metadata;
       expect(meta).to.deep.equal({
         class: {
+          'ravel': {'instance': app },
           '@before': { middleware: ['middleware1'] },
           '@mapping': {
             'Symbol(get) /path':{
@@ -149,6 +151,7 @@ describe('Ravel', function() {
 
       expect(meta).to.deep.equal({
         class: {
+          'ravel': {'instance': app },
           '@before': { middleware: ['middleware1'] },
           '@mapping': {
             'Symbol(get) /': { verb: Resource.GET, path: '/', status: 501 },

--- a/test/core/test-resource.js
+++ b/test/core/test-resource.js
@@ -84,26 +84,26 @@ describe('Ravel', function() {
           super('/api/test');
           expect(a).to.equal(another);
           expect(this).to.have.property('basePath').that.equals('/api/test');
+          expect(this.log).to.be.an('object');
+          expect(this.log).to.have.property('trace').that.is.a('function');
+          expect(this.log).to.have.property('verbose').that.is.a('function');
+          expect(this.log).to.have.property('debug').that.is.a('function');
+          expect(this.log).to.have.property('info').that.is.a('function');
+          expect(this.log).to.have.property('warn').that.is.a('function');
+          expect(this.log).to.have.property('error').that.is.a('function');
+          expect(this.log).to.have.property('critical').that.is.a('function');
+          expect(this).to.have.property('respond').that.is.a('function');
+          expect(this.ApplicationError).to.equal(Ravel.ApplicationError);
+          expect(this.kvstore).to.equal(Ravel.kvstore);
+          expect(this.params).to.be.an.object;
+          expect(this.params).to.have.a.property('get').that.is.a.function;
         }
       };
 
       mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
       Ravel.resource('test');
       const router = require('koa-router')();
-      const resource = Ravel[coreSymbols.resourceFactories].test(router);
-      expect(resource.log).to.be.an('object');
-      expect(resource.log).to.have.property('trace').that.is.a('function');
-      expect(resource.log).to.have.property('verbose').that.is.a('function');
-      expect(resource.log).to.have.property('debug').that.is.a('function');
-      expect(resource.log).to.have.property('info').that.is.a('function');
-      expect(resource.log).to.have.property('warn').that.is.a('function');
-      expect(resource.log).to.have.property('error').that.is.a('function');
-      expect(resource.log).to.have.property('critical').that.is.a('function');
-      expect(resource).to.have.property('respond').that.is.a('function');
-      expect(resource.ApplicationError).to.equal(Ravel.ApplicationError);
-      expect(resource.kvstore).to.equal(Ravel.kvstore);
-      expect(resource.params).to.be.an.object;
-      expect(resource.params).to.have.a.property('get').that.is.a.function;
+      Ravel[coreSymbols.resourceFactories].test(router);
       done();
     });
 

--- a/test/core/test-routes.js
+++ b/test/core/test-routes.js
@@ -111,24 +111,23 @@ describe('Ravel', function() {
           super('/');
           expect(a).to.equal(another);
           expect(this).to.have.property('basePath').that.equals('/');
+          expect(this.log).to.be.ok;
+          expect(this.log).to.be.an('object');
+          expect(this.log).to.have.property('trace').that.is.a('function');
+          expect(this.log).to.have.property('verbose').that.is.a('function');
+          expect(this.log).to.have.property('debug').that.is.a('function');
+          expect(this.log).to.have.property('info').that.is.a('function');
+          expect(this.log).to.have.property('warn').that.is.a('function');
+          expect(this.log).to.have.property('error').that.is.a('function');
+          expect(this.log).to.have.property('critical').that.is.a('function');
+          expect(this.ApplicationError).to.equal(Ravel.ApplicationError);
+          expect(this.kvstore).to.equal(Ravel.kvstore);
+          expect(this.params).to.be.an.object;
+          expect(this.params).to.have.a.property('get').that.is.a.function;
         }
       };
       mockery.registerMock(upath.join(Ravel.cwd, 'stub'), Stub);
       Ravel.routes('stub');
-      const instance = Ravel[coreSymbols.routesFactories].stub();
-      expect(instance.log).to.be.ok;
-      expect(instance.log).to.be.an('object');
-      expect(instance.log).to.have.property('trace').that.is.a('function');
-      expect(instance.log).to.have.property('verbose').that.is.a('function');
-      expect(instance.log).to.have.property('debug').that.is.a('function');
-      expect(instance.log).to.have.property('info').that.is.a('function');
-      expect(instance.log).to.have.property('warn').that.is.a('function');
-      expect(instance.log).to.have.property('error').that.is.a('function');
-      expect(instance.log).to.have.property('critical').that.is.a('function');
-      expect(instance.ApplicationError).to.equal(Ravel.ApplicationError);
-      expect(instance.kvstore).to.equal(Ravel.kvstore);
-      expect(instance.params).to.be.an.object;
-      expect(instance.params).to.have.a.property('get').that.is.a.function;
       done();
     });
 

--- a/test/ravel/test-ravel-lifecycle.js
+++ b/test/ravel/test-ravel-lifecycle.js
@@ -37,7 +37,7 @@ describe('Ravel lifeycle test', function() {
     const postinit = Ravel.Module.postinit;
     const prelisten = Ravel.Module.prelisten;
     const postlisten = Ravel.Module.postlisten;
-    const end = Ravel.Module.end;
+    const preclose = Ravel.Module.preclose;
     postinitHandlerCalled = 0;
     prelistenHandlerCalled = 0;
     postlistenHandlerCalled = 0;
@@ -80,7 +80,7 @@ describe('Ravel lifeycle test', function() {
         postlistenHandlerCalled += 1;
       }
 
-      @end
+      @preclose
       doEnd() {
         endHandlerCalled += 1;
       }

--- a/test/ravel/test-ravel.js
+++ b/test/ravel/test-ravel.js
@@ -47,6 +47,7 @@ describe('Ravel end-to-end test', function() {
           }
 
           getAllUsers() {
+            expect(this).to.have.a.property('params').that.is.an('object');
             return Promise.resolve(u);
           }
 
@@ -71,6 +72,7 @@ describe('Ravel end-to-end test', function() {
 
           @pre('respond')
           getAll(ctx) {
+            expect(this).to.have.a.property('params').that.is.an('object');
             return this.users.getAllUsers()
             .then((list) => {
               ctx.body = list;


### PR DESCRIPTION
Fixes #87 