### PR TITLE
Load default params even in the absence of a .ravelrc file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,8 @@
 /test
+.babelrc
+.codeclimate.yml
+.editorconfig
+.eslintrc.json
+.travis.yml
+gulpfile.js
+/lib/.eslintrc.json

--- a/lib/core/params.js
+++ b/lib/core/params.js
@@ -27,6 +27,7 @@ module.exports = function(Ravel) {
     // load parameters from config into an empty object
     const sources = rc('ravel', defaults);
 
+    // if there is a .ravelrc file, verify all parameters are known
     if (sources.configs && sources.configs.length > 0) {
       delete sources.configs;
       delete sources.config;
@@ -38,11 +39,11 @@ module.exports = function(Ravel) {
             `Attempted to set unknown parameter: ${key.toString()}`);
         }
       }
-
-      // now merge with this[symbols.params], allowing programmatically set params to take precedence
-      Object.assign(defaults, this[symbols.params]);
-      this[symbols.params] = defaults;
     }
+
+    // now merge with this[symbols.params], allowing programmatically set params to take precedence
+    Object.assign(defaults, this[symbols.params]);
+    this[symbols.params] = defaults;
   };
 
   /**

--- a/test/core/test-params.js
+++ b/test/core/test-params.js
@@ -22,6 +22,7 @@ describe('Ravel', function() {
       target.configs = files;
       return target;
     });
+    mockery.registerMock('redis', require('redis-mock'));
     Ravel = new (require('../../lib/ravel'))();
     coreSymbols = require('../../lib/core/symbols');
     Ravel.log.setLevel('NONE');
@@ -159,13 +160,25 @@ describe('Ravel', function() {
       done();
     });
 
-    it('should do nothing if no configuration files are present', (done) => {
+    it('should load defaults if no configuration files are present', (done) => {
       files = [];
       conf = undefined;
 
-      const oldParams = Object.create(null);
-      Object.assign(oldParams, Ravel.config);
-      Ravel[coreSymbols.loadParameters]();
+      const oldParams = {
+        'redis host': '0.0.0.0',
+        'redis port': 6379,
+        'redis max retries': 10,
+        'port':  8080,
+        'app route': '/',
+        'login route': '/login',
+        'keygrip keys': ['123abc'],
+        'log level': 'DEBUG',
+        'configs': [],
+        'authentication providers': []
+      };
+      Ravel.set('keygrip keys', ['123abc']);
+      Ravel.init();
+      // now load params from non-existent ravelrc file
       expect(Ravel.config).to.deep.equal(oldParams);
       done();
     });


### PR DESCRIPTION
Fixes #135 