### PR TITLE
Replacing koa-redis with internal implementation

### DIFF
--- a/lib/ravel.js
+++ b/lib/ravel.js
@@ -170,7 +170,6 @@ class Ravel extends EventEmitter {
     const koa = require('koa');
     const session = require('koa-generic-session');
     const compression = require('koa-compress');
-    const redisStore = require('koa-redis');
     const favicon = require('koa-favicon');
     const router = require('koa-router')();
 
@@ -200,7 +199,7 @@ class Ravel extends EventEmitter {
       sessionStoreArgs.pass = this.get('redis password');
     }
     app.use(session({
-      store: redisStore(sessionStoreArgs),
+      store: new (require('./util/redis_session_store'))(this),
       cookie: {
         path: '/',
         httpOnly: true,

--- a/lib/util/redis_session_store.js
+++ b/lib/util/redis_session_store.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const EventEmitter = require('events').EventEmitter;
+const sRavelInstance = Symbol();
+
+function finishBasicPromise(resolve, reject) {
+  return (err, res) => {
+    if (err) { return reject(err); }
+    else { return resolve(res); }
+  };
+};
+
+class RedisSessionStore extends EventEmitter {
+  constructor(ravelInstance) {
+    super();
+    this[sRavelInstance] = ravelInstance;
+    this[sRavelInstance].kvstore.on('connect', this.emit.bind(this, 'connect'));
+    if (this[sRavelInstance].kvstore.connected) {
+      this.emit('connect');
+    }
+    this[sRavelInstance].kvstore.on('error', this.emit.bind(this, 'error'));
+    this[sRavelInstance].kvstore.on('end', this.emit.bind(this, 'end'));
+    this[sRavelInstance].kvstore.on('end', this.emit.bind(this, 'disconnect')); // For backwards compatibility
+    this[sRavelInstance].kvstore.on('connect', this.emit.bind(this, 'connect'));
+    this[sRavelInstance].kvstore.on('reconnecting', this.emit.bind(this, 'reconnecting'));
+    this[sRavelInstance].kvstore.on('ready', this.emit.bind(this, 'ready'));
+    this[sRavelInstance].kvstore.on('warning', this.emit.bind(this, 'warning'));
+  }
+
+  get connected() {
+    return this[sRavelInstance].kvstore.connected;
+  }
+
+  get(sid) {
+    return new Promise((resolve, reject) => {
+      this[sRavelInstance].kvstore.get(sid, (err, res) => {
+        if (err) { return reject(err); }
+        else if (res !== null && res !== undefined) { return resolve(JSON.parse(res)); }
+        else { return resolve(res); }
+      });
+    });
+  }
+
+  set(sid, sess, ttl) {
+    return new Promise((resolve, reject) => {
+      if (typeof ttl === 'number') {
+        ttl = Math.ceil(ttl / 1000);
+      }
+      const jsess = JSON.stringify(sess);
+      if (ttl !== undefined) {
+        this[sRavelInstance].kvstore.setex(sid, ttl, jsess, finishBasicPromise(resolve, reject));
+      } else {
+        this[sRavelInstance].kvstore.set(sid, jsess, finishBasicPromise(resolve, reject));
+      }
+    });
+  }
+
+  destroy(sid) {
+    return new Promise((resolve, reject) => {
+      this[sRavelInstance].kvstore.del(sid, finishBasicPromise(resolve, reject));
+    });
+  }
+
+  quit() {
+    // Do nothing. We'll let ravel manage its own redis connection - we're just borrowing it.
+  }
+
+  end() {
+    this.quit();
+  }
+}
+
+module.exports = RedisSessionStore;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravel",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "author": "Sean McIntyre <s.mcintyre@xverba.ca>",
   "description": "Ravel Rapid Application Development Framework",
   "engines": {
@@ -49,7 +49,6 @@
     "koa-favicon": "1.2.1",
     "koa-generic-session": "1.10.2",
     "koa-passport": "1.3.1",
-    "koa-redis": "2.0.1",
     "koa-router": "5.4.0",
     "koa-static": "2.0.0",
     "koa-views": "4.1.0",

--- a/test/util/test-redis-session-store.js
+++ b/test/util/test-redis-session-store.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+chai.use(require('chai-as-promised'));
+const mockery = require('mockery');
+chai.use(require('sinon-chai'));
+const sinon = require('sinon');
+
+let Ravel, RedisMock, store;
+
+describe('util/rest', () => {
+  beforeEach((done) => {
+    //enable mockery
+    mockery.enable({
+      useCleanCache: true,
+      warnOnReplace: false,
+      warnOnUnregistered: false
+    });
+    RedisMock = require('redis-mock');
+    mockery.registerMock('redis', RedisMock);
+    Ravel = new (require('../../lib/ravel'))();
+    Ravel.log.setLevel('NONE');
+    Ravel.kvstore = RedisMock.createClient();
+    Ravel.kvstore.connected = true;
+    store = new (require('../../lib/util/redis_session_store'))(Ravel);
+    done();
+  });
+
+  afterEach((done) => {
+    Ravel = undefined;
+    RedisMock = undefined;
+    store = undefined;
+    mockery.deregisterAll();
+    mockery.disable();
+    done();
+  });
+
+  describe('RedisSessionStore', () => {
+
+    describe('#connected()', () => {
+      it('should return true iff the redis client is connected', (done) => {
+        Ravel.kvstore.connected = true;
+        expect(store.connected).to.be.true;
+        Ravel.kvstore.connected = false;
+        expect(store.connected).to.be.false;
+        done();
+      });
+    });
+
+    describe('#get()', () => {
+      it('should return a Promise which resolves with a JSON object representing the user\'s session', () => {
+        const session = {'username': 'smcintyre'};
+        Ravel.kvstore.set('koa:sess:1234', JSON.stringify(session));
+        return expect(store.get('koa:sess:1234')).to.eventually.deep.equal(session);
+      });
+
+      it('should return a Promise which rejects if the specified session id does not exist', () => {
+        return expect(store.get('koa:sess:1234')).to.reject;
+      });
+
+      it('should return a Promise which rejects if redis calls back with an error', () => {
+        const session = {'username': 'smcintyre'};
+        const getError = new Error();
+        sinon.stub(Ravel.kvstore, 'get', (key, cb) => cb(getError));
+        Ravel.kvstore.set('koa:sess:1234', JSON.stringify(session));
+        return expect(store.get('koa:sess:1234')).to.be.rejectedWith(getError);
+      });
+    });
+
+    describe('#set()', () => {
+      it('should return a Promise which resolves after storing the user\'s session', () => {
+        const session = {'username': 'smcintyre'};
+        return Promise.all([
+          expect(store.set('koa:sess:1234', session)).to.be.fulfilled,
+          expect(store.get('koa:sess:1234')).to.eventually.deep.equal(session)
+        ]);
+      });
+
+      it('should return a Promise which resolves after storing the user\'s session with a ttl', () => {
+        const session = {'username': 'smcintyre'};
+        // setex from redis-mock sets a timeout, which stops test from exiting cleanly. Just stub it as set.
+        const setexSpy = sinon.stub(Ravel.kvstore, 'setex', function(key, ttl, value, cb) {
+          Ravel.kvstore.set(key, value, cb);
+        });
+        return Promise.all([
+          expect(store.set('koa:sess:1234', session, 1000*1000)).to.be.fulfilled,
+          expect(store.get('koa:sess:1234')).to.eventually.deep.equal(session)
+        ]).then(() => {
+          // redis mock doesn't support ttls, so we just check to see if setex was called
+          expect(setexSpy).to.have.been.calledWith('koa:sess:1234', 1000, JSON.stringify(session));
+        });
+      });
+
+      it('should return a Promise which rejects if redis calls back with an error', () => {
+        const session = {'username': 'smcintyre'};
+        const setError = new Error();
+        sinon.stub(Ravel.kvstore, 'set', (key, value, cb) => cb(setError));
+        return expect(store.set('koa:sess:1234', session)).to.be.rejectedWith(setError);
+      });
+
+      it('should return a Promise which rejects if redis calls back with an error (ttl version)', () => {
+        const session = {'username': 'smcintyre'};
+        const setexError = new Error();
+        sinon.stub(Ravel.kvstore, 'setex', (key, value, ttl, cb) => cb(setexError));
+        return expect(store.set('koa:sess:1234', session, 1000*1000)).to.be.rejectedWith(setexError);
+      });
+    });
+
+    describe('#destroy()', () => {
+      it('should remove a session from redis', () => {
+        const session = {'username': 'smcintyre'};
+        return Promise.all([
+          expect(store.set('koa:sess:1234', session)).to.be.fulfilled,
+          expect(store.get('koa:sess:1234')).to.eventually.deep.equal(session),
+          expect(store.destroy('koa:sess:1234')).to.be.fulfilled,
+          expect(store.get('koa:sess:1234')).to.eventually.equal(null)
+        ]);
+      });
+
+      it('should return a Promise which rejects if redis calls back with an error (ttl version)', () => {
+        const delError = new Error();
+        sinon.stub(Ravel.kvstore, 'del', (key, cb) => cb(delError));
+        return expect(store.destroy('koa:sess:1234')).to.be.rejectedWith(delError);
+      });
+    });
+
+    describe('#quit()', () => {
+      it('should do nothing', (done) => {
+        store.quit();
+        done();
+      });
+    });
+
+    describe('#end()', () => {
+      it('should do nothing', (done) => {
+        store.end();
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
Cuts down on unnecessary dependencies.