### PR TITLE
Non-ravel errors thrown in a routes/resource handler should have their message included in the response body

### DIFF
--- a/lib/util/rest.js
+++ b/lib/util/rest.js
@@ -97,11 +97,12 @@ class Rest {
       } catch (err) {
         if (err instanceof self[sRavelInstance].ApplicationError.General) {
           this.response.status = err.code;
-          this.response.body = err.message;
         } else {
           self[sRavelInstance].log.trace(err.stack);
           this.response.status = httpCodes.INTERNAL_SERVER_ERROR;
         }
+        // always overwrite body with error message
+        this.response.body = err.message;
       }
     };
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravel",
-  "version": "0.17.13",
+  "version": "0.17.14",
   "author": "Sean McIntyre <s.mcintyre@xverba.ca>",
   "description": "Ravel Rapid Application Development Framework",
   "engines": {

--- a/test/util/test-rest.js
+++ b/test/util/test-rest.js
@@ -199,7 +199,7 @@ describe('util/rest', function() {
       });
       request(app.callback())
       .get('/')
-      .expect(500, 'Internal Server Error', done); // error message should not be exposed
+      .expect(500, 'a message', done); // error message should not be exposed
     });
   });
 });


### PR DESCRIPTION
Fixes  #163 