### PR TITLE
Feature/async await

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
-  "plugins": ["transform-decorators-legacy", "transform-async-to-generator"],
+  "plugins": ["transform-decorators-legacy"],
   "only": [
     "test/**/*.js"
   ],

--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,0 @@
-{
-  "plugins": ["transform-decorators-legacy"],
-  "only": [
-    "test/**/*.js"
-  ],
-  "retainLines": true
-}

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "plugins": ["transform-decorators-legacy", "transform-async-to-generator"],
+  "only": [
+    "test/**/*.js"
+  ],
+  "retainLines": true
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     "builtin": true,
     "es6": true
   },
+  "parser": "babel-eslint",
   "globals": {},
   "rules": {
     "block-scoped-var": 2,

--- a/README.md
+++ b/README.md
@@ -803,8 +803,8 @@ class DatabaseInitializer extends Module {
     // specify one or more providers to open connections to, or none
     // to open connections to all known DatabaseProviders.
     this.db.scoped('mysql', async function(ctx) {
-      // this generator function behaves like koa middleware,
-      // so feel free to yield promises!
+      // this async function behaves like koa middleware,
+      // so feel free to await on promises!
       await self.createTables(ctx.transaction.mysql);
       await self.insertRows(ctx.transaction.mysql);
       // notice that this.transaction is identical to ctx.transaction

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Ravel is layered on top of awesome technologies, including:
 
 ## Installation
 
-> As Ravel uses several ES2015 features, you will need to use a 6.x+ distribution of node.
+> As Ravel uses several ES2015/2016 features, you will need to use a 7.x+ distribution of node with the --harmony_async_await flag.
 
 ```bash
 $ npm install ravel
@@ -162,15 +162,15 @@ class ExampleRoutes extends Routes {
     super('/'); // base path for all routes in this class. Will be prepended to the @mapping.
     this.middleware1 = middleware1;
     // you can also build middleware right here!
-    this.middleware2 = function*(next) {
-      yield next;
+    this.middleware2 = async function(next) {
+      await next;
     };
   }
 
   // bind this method to an endpoint and verb with @mapping. This one will become GET /app
   @mapping(Routes.GET, 'app')
   @before('middleware1','middleware2') // use @before to place middleware before appHandler
-  *appHandler(ctx) {
+  async appHandler(ctx) {
     // ctx is just a koa context! Have a look at the koa docs to see what methods and properties are available.
     ctx.body = '<!DOCTYPE html><html><body>Hello World!</body></html>';
     ctx.status = 200;
@@ -204,19 +204,19 @@ class CitiesResource extends Resource {
     this.cities = cities;
 
     // some other middleware, which you might have injected from a Module or created here
-    this.anotherMiddleware = function*(next) {
-      yield next;
+    this.anotherMiddleware = async function(next) {
+      await next;
     };
   }
 
   // no need to use @mapping here. Routes methods are automatically mapped using their names.
-  *getAll(ctx) { // just like in Routes, ctx is a koa context.
-    ctx.body = yield this.cities.getAllCities();
+  async getAll(ctx) { // just like in Routes, ctx is a koa context.
+    ctx.body = await this.cities.getAllCities();
   }
 
   @before('anotherMiddleware') // using @before at the method level decorates this method with middleware
-  *get(ctx) { // get routes automatically receive an endpoint of /cities/:id (in this case).
-    ctx.body = yield this.cities.getCity(ctx.params.id);
+  async get(ctx) { // get routes automatically receive an endpoint of /cities/:id (in this case).
+    ctx.body = await this.cities.getCity(ctx.params.id);
   }
 
   // post, put, putAll, delete and deleteAll are
@@ -250,25 +250,23 @@ app.start();
 
 ### Decorator Transpilation
 
-Since decorators are not yet available in Node, you will need to use a transpiler to convert them into ES2016-compliant code. We have chosen TypeScript as our recommended transpiler, as Babel [cannot currently transpile decorators on generator methods](https://github.com/babel/babylon/issues/13). Ravel will likely switch back to Babel when this issue is resolved (when the Decorator level 2+ spec is implemented).
-
-To be clear, we are apply TypeScript as *a transpiler for JavaScript*, not using TypeScript itself (though nothing should stop you from using TypeScript with Ravel if you wish).
+Since async functions are not yet available in Node, you will need to use a transpiler to convert them into ES2016-compliant code. We have chosen [Babel](https://babeljs.io/) as our recommended transpiler.
 
 ```bash
-$ npm install gulp-sourcemaps@1.6.0 typescript@1.8.10 gulp-typescript@2.13.6
+$ npm install gulp-sourcemaps@1.6.0 babel-core@6.18.2 babel-plugin-transform-decorators-legacy@1.3.4 gulp-babel@6.1.2
+# Note, please add babel-plugin-transform-async-to-generator@6.16.0 if you are using Node v6 instead of v7.
 ```
 
 *gulpfile.js*
 ```js
+const babelConfig = {
+  'retainLines': true,
+  'plugins': ['transform-decorators-legacy'] // add 'transform-async-to-generator' if you are using Node v6 instead of v7
+};
 gulp.task('transpile', function() {
   return gulp.src('src/**/*.js') // point it at your source directory, containing Modules, Resources and Routes
       .pipe(plugins.sourcemaps.init())
-      .pipe(plugins.typescript({
-        typescript: require('typescript'),
-        allowJs: true,
-        experimentalDecorators: true,
-        target: 'ES6',
-      }))
+      .pipe(plugins.babel(babelConfig))
       .pipe(plugins.sourcemaps.write('.'))
       .pipe(gulp.dest('dist'));  // your transpiled Ravel app will appear here!
 });
@@ -455,7 +453,11 @@ class MyModule extends Module {
 
   // implement any methods you like :)
   aMethod() {
-    //...
+    // ...
+  }
+
+  async anAsyncMethod() {
+    // ...
   }
 }
 
@@ -585,7 +587,7 @@ There are currently five lifecycle decorators:
 
 Like `Module`s, `Routes` classes support dependency injection, allowing easy connection of application logic and web layers.
 
-Endpoints are created within a `Routes` class by creating a generator method and then decorating it with [`@mapping`](http://raveljs.github.io/docs/latest/core/decorators/mapping.js.html). The `@mapping` decorator indicates the path for the route (concatenated with the base path passed to `super()` in the `constructor`), as well as the HTTP verb. The method handler accepts a single argument `ctx` which is a [koa context](http://koajs.com/#context). Savvy readers with `koa` experience will note that, within the handler, `this` refers to the instance of the Routes class (to make it easy to access injected `Module`s), and the passed `ctx` argument is a reference to the `koa` context (rather than `this`).
+Endpoints are created within a `Routes` class by creating an `async` method and then decorating it with [`@mapping`](http://raveljs.github.io/docs/latest/core/decorators/mapping.js.html). The `@mapping` decorator indicates the path for the route (concatenated with the base path passed to `super()` in the `constructor`), as well as the HTTP verb. The method handler accepts a single argument `ctx` which is a [koa context](http://koajs.com/#context). Savvy readers with `koa` experience will note that, within the handler, `this` refers to the instance of the Routes class (to make it easy to access injected `Module`s), and the passed `ctx` argument is a reference to the `koa` context.
 
 *routes/my-routes.js*
 ```js
@@ -595,14 +597,14 @@ const mapping = Routes.mapping; // Ravel decorator for mapping a method to an en
 const before = Routes.before;   // Ravel decorator for conneting middleware to an endpoint
 
 // you can inject your own Modules and npm dependencies into Routes
-@inject('koa-better-body', 'fs', 'custom-module')
+@inject('koa-convert', 'koa-better-body', 'fs', 'custom-module')
 class MyRoutes extends Routes {
   // The constructor for a `Routes` class must call `super()` with the base
   // path for all routes within that class. Koa path parameters such as
   // :something are supported.
-  constructor(bodyParser, fs, custom) {
+  constructor(convert, bodyParser, fs, custom) {
     super('/'); // base path for all routes in this class
-    this.bodyParser = bodyParser(); // make bodyParser middleware available
+    this.bodyParser = convert(bodyParser()); // make bodyParser middleware available, and async-await compatible
     this.fs = fs;
     this.custom = custom;
   }
@@ -610,11 +612,11 @@ class MyRoutes extends Routes {
   // will map to GET /app
   @mapping(Routes.GET, 'app'); // Koa path parameters such as :something are supported
   @before('bodyParser') // use bodyParser middleware before handler. Matches this.bodyParser created in the constructor.
-  *appHandler(ctx) {
+  async appHandler(ctx) {
     ctx.status = 200;
     ctx.body = '<!doctype html><html></html>';
     // ctx is a koa context object.
-    // yield to Promises and use ctx to create a body/status code for response
+    // await on Promises and use ctx to create a body/status code for response
     // throw a Ravel.Error to automatically set an error status code
   }
 }
@@ -639,7 +641,7 @@ app.routes('./routes/my-routes');
 
 What might be referred to as a *controller* in other frameworks, a `Resource` module defines HTTP methods on an endpoint. `Resource`s also support dependency injection, allowing for the easy creation of RESTful interfaces to your `Module`-based application logic. Resources are really just a thin wrapper around `Routes`, using specially-named handler methods (`get`, `getAll`, `post`, `put`, `putAll`, `delete`, `deleteAll`) instead of `@mapping`. This convention-over-configuration approach makes it easier to write proper REST APIs with less code, and is recommended over ~~carefully chosen~~ `@mapping`s in a `Routes` class. Omitting any or all of the specially-named handler functions is fine, and will result in a `501 NOT IMPLEMENTED` status when that particular method/endpoint is requested. `Resource`s inherit all the properties, methods and decorators of `Routes`. See [core/routes](routes.js.html) for more information. Note that `@mapping` does not apply to `Resources`.
 
-As with `Routes` classes, `Resource` handler methods are generator functions which receive a [koa context](http://koajs.com/#context) as their only argument.
+As with `Routes` classes, `Resource` handler methods are `async` functions which receive a [koa context](http://koajs.com/#context) as their only argument.
 
 *resources/person-resource.js*
 ```js
@@ -648,42 +650,42 @@ const Resource = require('ravel').Resource;
 const before = Routes.before;
 
 // you can inject your own Modules and npm dependencies into Resources
-@inject('koa-better-body', 'fs', 'custom-module')
+@inject('koa-convert', 'koa-better-body', 'fs', 'custom-module')
 class PersonResource extends Resource {
-  constructor(bodyParser, fs, custom) {
+  constructor(convert, bodyParser, fs, custom) {
     super('/person'); // base path for all routes in this class
-    this.bodyParser = bodyParser(); // make bodyParser middleware available
+    this.bodyParser = convert(bodyParser()); // make bodyParser middleware available
     this.fs = fs;
     this.custom = custom;
   }
 
   // will map to GET /person
   @before('bodyParser') // use bodyParser middleware before handler
-  *getAll(ctx) {
+  async getAll(ctx) {
     // ctx is a koa context object.
-    // yield to Promises and use ctx to create a body/status code for response
+    // await on Promises and use ctx to create a body/status code for response
     // throw a Ravel.Error to automatically set an error status code
   }
 
   // will map to GET /person/:id
-  *get(ctx) {
+  async get(ctx) {
     // can use ctx.params.id in here automatically
   }
 
   // will map to POST /person
-  *post(ctx) {}
+  async post(ctx) {}
 
   // will map to PUT /person
-  *putAll(ctx) {}
+  async putAll(ctx) {}
 
   // will map to PUT /person/:id
-  *put(ctx) {}
+  async put(ctx) {}
 
   // will map to DELETE /person
-  *deleteAll(ctx) {}
+  async deleteAll(ctx) {}
 
   // will map to DELETE /person/:id
-  *delete(ctx) {}
+  async delete(ctx) {}
 }
 
 module.exports = PersonResource
@@ -767,11 +769,11 @@ class PersonResource extends Resource {
 
   // maps to GET /person/:id
   @transaction('mysql') // this is the name exposed by ravel-mysql-provider
-  *get(ctx) {
+  async get(ctx) {
     // TIP: Don't write complex logic here. Pass ctx.transaction into
     // a Module function which returns a Promise! This example is
     // just for demonstration purposes.
-    ctx.body = yield new Promise((resolve, reject) => {
+    ctx.body = await new Promise((resolve, reject) => {
       // ctx.transaction.mysql is a https://github.com/felixge/node-mysql connection
       ctx.transaction.mysql.query('SELECT 1', (err, rows) => {
         if (err) return reject(err);
@@ -786,7 +788,7 @@ module.exports = PersonResource;
 ### Scoped Transactions
 > [<small>View API docs &#128366;</small>](http://raveljs.github.io/docs/latest/core/module.js.html)
 
-Sometimes, you may need to open a transaction outside of a code path triggered by an HTTP request. Good examples of this might include database initialization at application start-time, or logic triggered by a websocket connection. In these cases, a `Module` class can open a `scoped` transaction using the names of the DatabaseProviders you are interested in, and a generator function (scope) in which to use the connections. Scoped transactions only exist for the scope of the generator function and are automatically cleaned up at the end of the function. It is best to view `Module.db.scoped()` as an identical mechanism to `@transaction`, behaving in exactly the same way, with a slightly different API:
+Sometimes, you may need to open a transaction outside of a code path triggered by an HTTP request. Good examples of this might include database initialization at application start-time, or logic triggered by a websocket connection. In these cases, a `Module` class can open a `scoped` transaction using the names of the DatabaseProviders you are interested in, and an `async` function (scope) in which to use the connections. Scoped transactions only exist for the scope of the `async` function and are automatically cleaned up at the end of the function. It is best to view `Module.db.scoped()` as an identical mechanism to `@transaction`, behaving in exactly the same way, with a slightly different API:
 
 *modules/database-initializer.js*
 ```js
@@ -800,11 +802,11 @@ class DatabaseInitializer extends Module {
     const self = this;
     // specify one or more providers to open connections to, or none
     // to open connections to all known DatabaseProviders.
-    this.db.scoped('mysql', function*() {
+    this.db.scoped('mysql', async function(ctx) {
       // this generator function behaves like koa middleware,
       // so feel free to yield promises!
-      yield self.createTables(this.transaction.mysql);
-      yield self.insertRows(this.transaction.mysql);
+      await self.createTables(ctx.transaction.mysql);
+      await self.insertRows(ctx.transaction.mysql);
       // notice that this.transaction is identical to ctx.transaction
       // from @transaction! It's just a hash of open, named connections
       // to the DatabaseProviders specified.
@@ -925,7 +927,7 @@ class MyRoutes extends Routes {
 
   @authenticated({redirect: true}) // protect one endpoint specifically
   @mapping(Routes.GET, 'app')
-  *handler(ctx) {
+  async handler(ctx) {
     // will redirect to app.get('login route') if not signed in
   }
 }
@@ -940,8 +942,8 @@ Ravel is designed for horizontal scaling, and helps you avoid common pitfalls wh
  - All Ravel dependencies are strictly locked (i.e. no use of `~` or `^` in `package.json`). This helps foster repeatability between members of your team, as well as between development/testing/production environments. Adherence to semver in the node ecosystem is unfortunately varied at best, so it is recommended that you follow the same practice in your app as well.
  - While it is possible to color outside the lines, Ravel provides a framework for developing **stateless** backend applications, where all stateful data is stored in external caches or databases.
 
-It is strongly encouraged that you containerize your Ravel app using an [Alpine-based docker container](https://hub.docker.com/r/mhart/alpine-node/), and then explore technologies such as [docker-compose](https://www.docker.com/products/docker-compose) or [kubernetes](http://kubernetes.io/) to appropriately scale out and link to (at least) the [official redis container](https://hub.docker.com/_/redis/). An example project with a reference `docker-compose` environment for Ravel is forthcoming, but for now please refer to the [nom project](https://github.com/nomjs/nomjs-registry) as a current example.
+It is strongly encouraged that you containerize your Ravel app using an [Alpine-based docker container](https://hub.docker.com/r/mhart/alpine-node/), and then explore technologies such as [docker-compose](https://www.docker.com/products/docker-compose) or [kubernetes](http://kubernetes.io/) to appropriately scale out and link to (at least) the [official redis container](https://hub.docker.com/_/redis/). An example project with a reference `docker-compose` environment for Ravel can be found in the [starter project](https://github.com/raveljs/ravel-github-mariadb-starter).
 
 Ravel does not explicitly require [hiredis](https://github.com/redis/hiredis-node), but is is highly recommended that you install it alongside Ravel for improved redis performance.
 
-If you are looking for a good way to share `.ravelrc.json` configuration between multiple replicas of the same Ravel app, have a look at [ravel-etcd-config](https://github.com/raveljs/ravel-etcd-config).
+If you are looking for a good way to share `.ravelrc.json` configuration between multiple replicas of the same Ravel app, have a look at [ravel-etcd-config](https://github.com/raveljs/ravel-etcd-config) for easy distributed configuration.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,13 +52,7 @@ gulp.task('cover', ['transpile'], function() {
 gulp.task('transpile', ['clean', 'lint'], function() {
   return gulp.src('test/**/*.js')
       .pipe(plugins.sourcemaps.init())
-      // .pipe(plugins.babel())
-      .pipe(plugins.typescript({
-        allowJs: true,
-        experimentalDecorators: true,
-        // emitDecoratorMetadata: true,
-        target: 'ES6',
-      }))
+      .pipe(plugins.babel())
       .pipe(plugins.sourcemaps.write('.'))
       .pipe(gulp.dest('test-dist'));
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,16 +8,27 @@ const exec = require('child_process').exec;
 const pkginfo = require('./package.json');
 
 const TESTS = [
-  'test-dist/core/decorators/test-*.js',
-  'test-dist/core/test-*.js',
-  'test-dist/db/test-*.js',
-  'test-dist/db/decorators/test-*.js',
-  'test-dist/util/test-*.js',
-  'test-dist/auth/test-*.js',
-  'test-dist/auth/decorators/test-*.js',
-  'test-dist/ravel/test-*.js',
-  'test-dist/**/test-*.js'
+  'test-dist/test/core/decorators/test-*.js',
+  'test-dist/test/core/test-*.js',
+  'test-dist/test/db/test-*.js',
+  'test-dist/test/db/decorators/test-*.js',
+  'test-dist/test/util/test-*.js',
+  'test-dist/test/auth/test-*.js',
+  'test-dist/test/auth/decorators/test-*.js',
+  'test-dist/test/ravel/test-*.js',
+  'test-dist/test/**/test-*.js'
 ];
+
+const babelConfig = {
+  'retainLines': true
+};
+if (process.execArgv.indexOf('--harmony_async_await') < 0) {
+  console.log('Transpiling async/await...');
+  babelConfig.plugins = ['transform-decorators-legacy', 'transform-async-to-generator'];
+} else {
+  console.log('Using native async/await...');
+  babelConfig.plugins = ['transform-decorators-legacy'];
+}
 
 gulp.task('lint', function() {
   return gulp.src(['./lib/**/*.js', './test/**/*.js', 'gulpfile.js'])
@@ -40,8 +51,8 @@ gulp.task('clean', function() {
   ]);
 });
 
-gulp.task('cover', ['transpile'], function() {
-  return gulp.src(['./lib/**/*.js'])
+gulp.task('cover-lib', ['transpile-lib'], function() {
+  return gulp.src(['./test-dist/lib/**/*.js'])
              .pipe(plugins.istanbul({
               //  instrumenter: isparta.Instrumenter,
                includeUntested: true
@@ -49,16 +60,29 @@ gulp.task('cover', ['transpile'], function() {
              .pipe(plugins.istanbul.hookRequire());
 });
 
-gulp.task('transpile', ['clean', 'lint'], function() {
+gulp.task('copy-lib', ['clean', 'lint'], function() {
+  return gulp.src('lib/**/*.js')
+      .pipe(gulp.dest('test-dist/lib'));
+});
+
+gulp.task('transpile-lib', ['clean', 'lint'], function() {
+  return gulp.src('lib/**/*.js')
+      .pipe(plugins.sourcemaps.init())
+      .pipe(plugins.babel(babelConfig))
+      .pipe(plugins.sourcemaps.write('.'))
+      .pipe(gulp.dest('test-dist/lib'));
+});
+
+gulp.task('transpile-tests', ['clean', 'lint'], function() {
   return gulp.src('test/**/*.js')
       .pipe(plugins.sourcemaps.init())
-      .pipe(plugins.babel())
+      .pipe(plugins.babel(babelConfig))
       .pipe(plugins.sourcemaps.write('.'))
-      .pipe(gulp.dest('test-dist'));
+      .pipe(gulp.dest('test-dist/test'));
 });
 
 //necessary to locate issues in code, due to https://github.com/gotwarlost/istanbul/issues/274
-gulp.task('test-no-cov', ['transpile'], function () {
+gulp.task('test-no-cov', ['copy-lib', 'transpile-tests'], function () {
   const env = plugins.env.set({
     LOG_LEVEL : 'critical'
   });
@@ -73,7 +97,7 @@ gulp.task('test-no-cov', ['transpile'], function () {
     .pipe(env.reset);
 });
 
-gulp.task('test', ['cover'], function () {
+gulp.task('test', ['cover-lib', 'transpile-tests'], function () {
   const env = plugins.env.set({
     LOG_LEVEL : 'critical'
   });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,15 +8,16 @@ const exec = require('child_process').exec;
 const pkginfo = require('./package.json');
 
 const TESTS = [
-  'test-dist/core/decorators/test-*.js',
-  'test-dist/core/test-*.js',
-  'test-dist/db/test-*.js',
-  'test-dist/db/decorators/test-*.js',
-  'test-dist/util/test-*.js',
-  'test-dist/auth/test-*.js',
-  'test-dist/auth/decorators/test-*.js',
-  'test-dist/ravel/test-*.js',
-  'test-dist/**/test-*.js'
+  // 'test-dist/core/decorators/test-*.js',
+  // 'test-dist/core/test-*.js',
+  'test-dist/core/test-resource.js',
+  // 'test-dist/db/test-*.js',
+  // 'test-dist/db/decorators/test-*.js',
+  // 'test-dist/util/test-*.js',
+  // 'test-dist/auth/test-*.js',
+  // 'test-dist/auth/decorators/test-*.js',
+  // 'test-dist/ravel/test-*.js',
+  // 'test-dist/**/test-*.js'
 ];
 
 gulp.task('lint', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,16 +8,15 @@ const exec = require('child_process').exec;
 const pkginfo = require('./package.json');
 
 const TESTS = [
-  // 'test-dist/core/decorators/test-*.js',
-  // 'test-dist/core/test-*.js',
-  'test-dist/core/test-resource.js',
-  // 'test-dist/db/test-*.js',
-  // 'test-dist/db/decorators/test-*.js',
-  // 'test-dist/util/test-*.js',
-  // 'test-dist/auth/test-*.js',
-  // 'test-dist/auth/decorators/test-*.js',
-  // 'test-dist/ravel/test-*.js',
-  // 'test-dist/**/test-*.js'
+  'test-dist/core/decorators/test-*.js',
+  'test-dist/core/test-*.js',
+  'test-dist/db/test-*.js',
+  'test-dist/db/decorators/test-*.js',
+  'test-dist/util/test-*.js',
+  'test-dist/auth/test-*.js',
+  'test-dist/auth/decorators/test-*.js',
+  'test-dist/ravel/test-*.js',
+  'test-dist/**/test-*.js'
 ];
 
 gulp.task('lint', function() {

--- a/lib/auth/authenticate_request.js
+++ b/lib/auth/authenticate_request.js
@@ -62,9 +62,9 @@ class AuthenticationMiddleware {
   }
 
   /**
-   * @return {Generator} koa-compatible middleware which validates a web session or mobile auth token,
-   *                     potentially redirecting if the user is not authenticated, or registering an
-   *                     unknown mobile client automatically.
+   * @return {AsyncFunction} koa-compatible middleware which validates a web session or mobile auth token,
+   *                         potentially redirecting if the user is not authenticated, or registering an
+   *                         unknown mobile client automatically.
    * @api private
    */
   middleware() {

--- a/lib/auth/authenticate_request.js
+++ b/lib/auth/authenticate_request.js
@@ -69,8 +69,7 @@ class AuthenticationMiddleware {
    */
   middleware() {
     const self = this;
-    return function*(next) {
-      const ctx = this;
+    return async function(ctx, next) {
 
       let promise;
       if (ctx.headers['x-auth-token'] && ctx.headers['x-auth-client']) {
@@ -100,9 +99,9 @@ class AuthenticationMiddleware {
       // catch all errors, regardless of client type, and behave appropriately
       let errorFromNext = false;
       try {
-        yield promise;
+        await promise;
         errorFromNext = true;
-        yield next;
+        await next;
       } catch (err) {
         if (!errorFromNext && self[sShouldRedirect]) {
           self[sRavelInstance].log.error(err);

--- a/lib/auth/authenticate_request.js
+++ b/lib/auth/authenticate_request.js
@@ -95,7 +95,7 @@ class AuthenticationMiddleware {
         promise = Promise.resolve();
       }
 
-      // try out the promise, and then try to yield next
+      // try out the promise, and then try to await next
       // catch all errors, regardless of client type, and behave appropriately
       let errorFromNext = false;
       try {

--- a/lib/auth/authenticate_request.js
+++ b/lib/auth/authenticate_request.js
@@ -101,7 +101,7 @@ class AuthenticationMiddleware {
       try {
         await promise;
         errorFromNext = true;
-        await next;
+        await next();
       } catch (err) {
         if (!errorFromNext && self[sShouldRedirect]) {
           self[sRavelInstance].log.error(err);

--- a/lib/auth/decorators/authenticated.js
+++ b/lib/auth/decorators/authenticated.js
@@ -34,7 +34,7 @@ const Metadata = require('../../util/meta');
  *
  *     &#64;authenticated({redirect: true}) // works at the method-level, with or without arguments
  *     &#64;mapping(Routes.GET, 'app')
- *     handler(ctx) {
+ *     async handler(ctx) {
  *       // will redirect to this.params.get('login route') if not signed in
  *     }
  *   }
@@ -50,7 +50,7 @@ const Metadata = require('../../util/meta');
  *       super('/');
  *     }
  *
- *     handler(ctx) {
+ *     async handler(ctx) {
  *       // will respond with a 401 if not signed in
  *     }
  *   }

--- a/lib/auth/passport_init.js
+++ b/lib/auth/passport_init.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const passport = require('koa-passport');
+const koaConvert = require('koa-convert');
 const ApplicationError = require('../util/application_error');
 const Metadata = require('../util/meta');
 const symbols = require('./symbols');
@@ -43,8 +44,8 @@ module.exports = function(ravelInstance, router) {
     const providers = ravelInstance.authenticationProviders();
 
     if (providers.length > 0) {
-      app.use(passport.initialize());
-      app.use(passport.session());
+      app.use(koaConvert(passport.initialize()));
+      app.use(koaConvert(passport.session()));
     }
   });
 

--- a/lib/core/decorators/before.js
+++ b/lib/core/decorators/before.js
@@ -11,7 +11,7 @@ const Metadata = require('../../util/meta');
  * Can also be applied at the class-level to place middleware before *all*
  * `@mapping` handlers.
  *
- * References any middleware `Generator`s available on `this`.
+ * References any middleware `AsyncFunction`s available on `this`.
  *
  * See [decorators/before](decorators/before.js.html) for more information.
  * @example
@@ -22,16 +22,16 @@ const Metadata = require('../../util/meta');
  *   const mapping = Routes.mapping;
  *   const before = Routes.before;
  *
- *   &#64;inject('koa-better-body')
+ *   &#64;inject('koa-convert', 'koa-better-body')
  *   class MyRoutes extends Routes {
- *     constructor(bodyParser) {
+ *     constructor(convert, bodyParser) {
  *       super('/');
- *       this.bodyParser = bodyParser();
+ *       this.bodyParser = convert(bodyParser());
  *     }
  *
  *     &#64;mapping(Routes.GET, '/projects/:id')
  *     &#64;before('bodyParser') // method-level version only applies to this route
- *     *handler(ctx) {
+ *     async handler(ctx) {
  *       // in here, bodyParser will already have run,
  *       // and ctx.body will be populated
  *     }
@@ -42,15 +42,15 @@ const Metadata = require('../../util/meta');
  *   const Routes = require('ravel').Resource;
  *   const before = Resource.before;
  *
- *   &#64;inject('koa-better-body')
+ *   &#64;inject('koa-convert', 'koa-better-body')
  *   &#64;before('bodyParser') // class-level version applies to all routes in class.
  *   class MyResource extends Resource {
- *     constructor(bodyParser) {
+ *     constructor(convert, bodyParser) {
  *       super('/');
- *       this.bodyParser = bodyParser();
+ *       this.bodyParser = convert(bodyParser());
  *     }
  *
- *     *get(ctx) {
+ *     async get(ctx) {
  *       // in here, bodyParser will already have run,
  *       // and ctx.body will be populated
  *     }

--- a/lib/core/decorators/mapping.js
+++ b/lib/core/decorators/mapping.js
@@ -26,7 +26,7 @@ const httpCodes = require('../../util/http_codes');
  *
  *     // will map to /projects
  *     &#64;mapping(Routes.GET, 'projects')
- *     *handler(ctx) {
+ *     async handler(ctx) {
  *       // ctx is a koa context object
  *     }
  *   }

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -41,9 +41,9 @@ const sInit = Symbol.for('_init');
  *
  *   class MyMiddleware extends Module {
  *
- *     *someMiddleware(next) {
+ *     async someMiddleware(ctx, next) {
  *       //...
- *       yield next;
+ *       await next;
  *     }
  *   }
  *
@@ -228,7 +228,7 @@ class Module {
    *       // like &#64;transaction, you can also supply no names (and
    *       // only the generator) to open connections to ALL registered
    *       // DatabaseProviders
-   *       this.db.scoped('mysql', 'rethinkdb', function*() {
+   *       this.db.scoped('mysql', 'rethinkdb', async function(ctx) {
    *         // can use ctx.transaction.mysql
    *         // can use ctx.transaction.rethinkdb
    *       });

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -225,8 +225,8 @@ class Module {
    *     &#64;prelisten
    *     doInitDb() {
    *       // open connections to specific, named database providers.
-   *       // like &#64;transaction, you can also supply no names (and
-   *       // only the generator) to open connections to ALL registered
+   *       // like &#64;transaction, you can also supply no names (just
+   *       // the async function) to open connections to ALL registered
    *       // DatabaseProviders
    *       this.db.scoped('mysql', 'rethinkdb', async function(ctx) {
    *         // can use ctx.transaction.mysql
@@ -235,8 +235,8 @@ class Module {
    *     }
    *   }
    * @example
-   *   this.db.scoped('mysql', function*() {
-   *     // this.transaction.mysql will be an open database connection
+   *   this.db.scoped('mysql', async function(ctx) {
+   *     // ctx.transaction.mysql will be an open database connection
    *   });
    */
   get db() {

--- a/lib/core/resource.js
+++ b/lib/core/resource.js
@@ -60,42 +60,42 @@ const buildRoute = function(ravelInstance, resource, methodType, methodName) {
  *   const before = Routes.before;
  *
  *   // you can inject your own Modules and npm dependencies into Resources
- *   &#64;inject('koa-better-body', 'fs', 'custom-module')
+ *   &#64;inject('koa-convert', 'koa-better-body', 'fs', 'custom-module')
  *   class PersonResource extends Resource {
- *     constructor(bodyParser, fs, custom) {
+ *     constructor(convert, bodyParser, fs, custom) {
  *       super('/person'); // base path for all routes in this class
- *       this.bodyParser = bodyParser(); // make bodyParser middleware available
+ *       this.bodyParser = convert(bodyParser()); // make bodyParser middleware available and async/await compatible
  *       this.fs = fs;
  *       this.custom = custom;
  *     }
  *
  *     // will map to GET /person
  *     &#64;before('bodyParser') // use bodyParser middleware before handler
- *     *getAll(ctx) {
+ *     async getAll(ctx) {
  *       // ctx is a koa context object.
- *       // yield to Promises, and use ctx to create a body/status code for response
+ *       // await on Promises, and use ctx to create a body/status code for response
  *       // throw a Ravel.Error to automatically set an error status code
  *     }
  *
  *     // will map to GET /person/:id
- *     *get(ctx) {
+ *     async get(ctx) {
  *       // can use ctx.params.id in here automatically
  *     }
  *
  *     // will map to POST /person
- *     *post(ctx) {}
+ *     async post(ctx) {}
  *
  *     // will map to PUT /person
- *     *putAll(ctx) {}
+ *     async putAll(ctx) {}
  *
  *     // will map to PUT /person/:id
- *     *put(ctx) {}
+ *     async put(ctx) {}
  *
  *     // will map to DELETE /person
- *     *deleteAll(ctx) {}
+ *     async deleteAll(ctx) {}
  *
  *     // will map to DELETE /person/:id
- *     *delete(ctx) {}
+ *     async delete(ctx) {}
  *   }
  *
  *   module.exports = PersonResource;
@@ -113,7 +113,7 @@ class Resource extends Routes {
    *     }
    *
    *     // will map to /user/:id
-   *     *get(ctx) {
+   *     async get(ctx) {
    *       // can access ctx.params.userId and ctx.params.id here
    *       // ...
    *     }

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -104,7 +104,7 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
         await result();
       }
       // now yield to next middleware
-      await next;
+      await next();
     });
   } else {
     // if there's no handler, this @mapping represents an endpoint which just returns a status code

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -122,11 +122,11 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
  *   const before = Routes.before;
  *
  *   // you can inject your own Modules and npm dependencies into Routes
- *   &#64;inject('koa-better-body', 'fs', 'custom-module')
+ *   &#64;inject('koa-convert', 'koa-better-body', 'fs', 'custom-module')
  *   class MyRoutes extends Routes {
- *     constructor(bodyParser, fs, custom) {
+ *     constructor(convert, bodyParser, fs, custom) {
  *       super('/'); // base path for all routes in this class
- *       this.bodyParser = bodyParser(); // make bodyParser middleware available
+ *       this.bodyParser = convert(bodyParser()); // make bodyParser middleware available and async/await compatible
  *       this.fs = fs;
  *       this.custom = custom;
  *     }
@@ -134,9 +134,9 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
  *     // will map to /app
  *     &#64;mapping(Routes.GET, 'app');
  *     &#64;before('bodyParser') // use bodyParser middleware before handler
- *     *appHandler(ctx) {
+ *     async appHandler(ctx) {
  *       // ctx is a koa context object.
- *       // yield Promises, and use ctx to create a body/status code for response
+ *       // await on Promises, and use ctx to create a body/status code for response
  *       // throw a Ravel.Error to automatically set an error status code
  *     }
  *   }
@@ -160,7 +160,7 @@ class Routes {
    *       super('/');
    *     }
    *     &#64;mapping(Routes.GET, '/something')
-   *     *handler(ctx) {
+   *     async handler(ctx) {
    *       //...
    *     }
    *   }
@@ -178,7 +178,7 @@ class Routes {
    *       super('/');
    *     }
    *     &#64;mapping(Routes.POST, '/something')
-   *     *handler(ctx) {
+   *     async handler(ctx) {
    *       //...
    *     }
    *   }
@@ -196,7 +196,7 @@ class Routes {
    *       super('/');
    *     }
    *     &#64;mapping(Routes.PUT, '/something')
-   *     *handler(ctx) {
+   *     async handler(ctx) {
    *       //...
    *     }
    *   }
@@ -214,7 +214,7 @@ class Routes {
    *       super('/');
    *     }
    *     &#64;mapping(Routes.DELETE, '/something')
-   *     *handler(ctx) {
+   *     async handler(ctx) {
    *       //...
    *     }
    *   }
@@ -235,7 +235,7 @@ class Routes {
    *
    *     // will map to /user/:id/projects/:id
    *     &#64;mapping(Routes.GET, '/projects/:id')
-   *     *handler(ctx) {
+   *     async handler(ctx) {
    *       // can access ctx.params.userId and ctx.params.id here
    *       // ...
    *     }

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -94,7 +94,7 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
       if (result && result instanceof Promise) {
         await result;
       }
-      // then yield to next middleware
+      // then await next middleware
       await next();
     });
   } else {

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -89,21 +89,12 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
   // finally push actual function handler, but wrap it with a generator
   if (meta.endpoint) {
     middleware.push(async function(ctx, next) {
-      let result;
-      // if our handler is an async function, we can await on it, otherwise just call
-      if (meta.endpoint.constructor.name === 'AsyncFunction') {
-        result = await meta.endpoint.bind(routes)(ctx);
-      } else {
-        result = meta.endpoint.bind(routes)(ctx);
-      }
-      // if handler isn't an async function, it might return a Promise or an Async function
-      // yield promises and async so that exceptions can be caught properly
-      if (result && result instanceof Promise) { //eslint-disable-line no-extra-parens
+      let result = meta.endpoint.bind(routes)(ctx);
+      // if handler returns a Promise, await on it
+      if (result && result instanceof Promise) {
         await result;
-      } else if (result && result.constructor.name === 'AsyncFunction') {
-        await result();
       }
-      // now yield to next middleware
+      // then yield to next middleware
       await next();
     });
   } else {

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -91,6 +91,9 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
     middleware.push(function*(next) {
       let result;
       // if our handler is a generator, we can yield to it, otherwise just call
+      // we need to ignore this right now because we can't create routes with generator functions due to
+      // a bug in Babel's decorator transform, where generators cannot be decorated.
+      /* istanbul ignore if  */
       if (meta.endpoint.constructor.name === 'GeneratorFunction') {
         result = yield meta.endpoint.bind(routes)(this);
       } else {
@@ -98,6 +101,7 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
       }
       // if it isn't a generator, it might return a yieldable
       // yield promises and generators so that exceptions can be caught properly
+      /* istanbul ignore else  */
       if (result instanceof Promise ||
         (result && result.constructor.name === 'GeneratorFunction')) { //eslint-disable-line no-extra-parens
         yield result;

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -88,32 +88,28 @@ const buildRoute = function(ravelInstance, routes, koaRouter, methodName, meta) 
 
   // finally push actual function handler, but wrap it with a generator
   if (meta.endpoint) {
-    middleware.push(function*(next) {
+    middleware.push(async function(ctx, next) {
       let result;
-      // if our handler is a generator, we can yield to it, otherwise just call
-      // we need to ignore this right now because we can't create routes with generator functions due to
-      // a bug in Babel's decorator transform, where generators cannot be decorated.
-      /* istanbul ignore if  */
-      if (meta.endpoint.constructor.name === 'GeneratorFunction') {
-        result = yield meta.endpoint.bind(routes)(this);
+      // if our handler is an async function, we can await on it, otherwise just call
+      if (meta.endpoint.constructor.name === 'AsyncFunction') {
+        result = await meta.endpoint.bind(routes)(ctx);
       } else {
-        result = meta.endpoint.bind(routes)(this);
+        result = meta.endpoint.bind(routes)(ctx);
       }
-      // if it isn't a generator, it might return a yieldable
-      // yield promises and generators so that exceptions can be caught properly
-      /* istanbul ignore else  */
-      if (result instanceof Promise ||
-        (result && result.constructor.name === 'GeneratorFunction')) { //eslint-disable-line no-extra-parens
-        yield result;
+      // if handler isn't an async function, it might return a Promise or an Async function
+      // yield promises and async so that exceptions can be caught properly
+      if (result && result instanceof Promise) { //eslint-disable-line no-extra-parens
+        await result;
+      } else if (result && result.constructor.name === 'AsyncFunction') {
+        await result();
       }
       // now yield to next middleware
-      yield next;
+      await next;
     });
   } else {
     // if there's no handler, this @mapping represents an endpoint which just returns a status code
-    middleware.push(function*(next) {
-      this.status = meta.status;
-      yield next;
+    middleware.push(async (ctx) => {
+      ctx.response.status = meta.status;
     });
   }
 

--- a/lib/db/database.js
+++ b/lib/db/database.js
@@ -39,7 +39,7 @@ class TransactionFactory {
       ctx.transaction = await self[sOpenConnections](providerNames, closers);
       //try yielding to next middleware and committing statements afterwards. Rollback if there was an error
       try {
-        await next;
+        await next();
         await self[sCloseConnections](closers, true);
       } catch (err) {
         try {
@@ -68,7 +68,7 @@ class TransactionFactory {
     let provs = args.slice(0, args.length-1);
 
     let ctx = Object.create(null);
-    await this.middleware(...provs)(ctx, scope);
+    return this.middleware(...provs)(ctx, async () => scope(ctx));
   }
 }
 

--- a/lib/db/database.js
+++ b/lib/db/database.js
@@ -1,8 +1,5 @@
 'use strict';
 
-const co = require('co');
-const koaCompose = require('koa-compose');
-
 const sRavelInstance = Symbol.for('_ravelInstance');
 const sOpenConnections = Symbol.for('_openConnections');
 const sCloseConnections = Symbol.for('_closeConnections');
@@ -37,16 +34,16 @@ class TransactionFactory {
    */
   middleware(...providerNames) {
     const self = this;
-    return function*(next) {
+    return async function(ctx, next) {
       const closers = [];
-      this.transaction = yield self[sOpenConnections](providerNames, closers);
+      ctx.transaction = await self[sOpenConnections](providerNames, closers);
       //try yielding to next middleware and committing statements afterwards. Rollback if there was an error
       try {
-        yield next;
-        yield self[sCloseConnections](closers, true);
+        await next;
+        await self[sCloseConnections](closers, true);
       } catch (err) {
         try {
-          yield self[sCloseConnections](closers, false);
+          await self[sCloseConnections](closers, false);
         } finally {
           throw err;
         }
@@ -60,23 +57,18 @@ class TransactionFactory {
    * `Module.db.scoped`. See [core/module](../core/module.js.html) for examples.
    *
    * @param {Array} args Arguments beginning with 0-N Strings representing providers to open connections on,
-   *                     followed by a generator function which Will be provided with a context which contains
+   *                     followed by an async function which Will be provided with a context which contains
    *                     this.transaction
    * @return {Promise} which is resolved when inGen is finished running, or rejected if
    *                   an error was thrown.
    * @api private
    */
-  scoped(...args) {
+  async scoped(...args) {
     let scope = args[args.length-1];
     let provs = args.slice(0, args.length-1);
 
     let ctx = Object.create(null);
-    const stack = [
-      this.middleware(...provs),
-      scope
-    ];
-
-    return co.wrap(koaCompose(stack)).call(ctx);
+    await this.middleware(...provs)(ctx, scope);
   }
 }
 
@@ -105,20 +97,19 @@ TransactionFactory.prototype[sOpenConnections] = function(providerNames, closers
       const sConnName = Symbol.for('name');
       const toOpen = providerNames.length === 0 ? providers : providers.filter(p => providerNames.indexOf(p.name) >= 0);
       // index provider promises in an array and use co to open connections.
-      co(function*() {
-        return yield toOpen.map(p =>  {
-          return p.getTransactionConnection()
-          // chain an extra then() on the end, which will store connection closing functions
-          // which will allow us to clean up if one of the opens fails.
-          .then((conn) => {
-            closers.push((shouldCommit) =>  {
-              return p.exitTransaction(conn, shouldCommit);
-            });
-            conn[sConnName] = p.name; // store name in promise for later
-            return conn;
+
+      Promise.all(toOpen.map(p =>  {
+        return p.getTransactionConnection()
+        // chain an extra then() on the end, which will store connection closing functions
+        // which will allow us to clean up if one of the opens fails.
+        .then((conn) => {
+          closers.push((shouldCommit) =>  {
+            return p.exitTransaction(conn, shouldCommit);
           });
+          conn[sConnName] = p.name; // store name in promise for later
+          return conn;
         });
-      }).then((connections) =>{
+      })).then((connections) =>{
         // convert array into map with provider names
         const connObj = Object.create(null);
         for (let c of connections) {

--- a/lib/db/database.js
+++ b/lib/db/database.js
@@ -37,7 +37,7 @@ class TransactionFactory {
     return async function(ctx, next) {
       const closers = [];
       ctx.transaction = await self[sOpenConnections](providerNames, closers);
-      //try yielding to next middleware and committing statements afterwards. Rollback if there was an error
+      //try awaiting on next middleware and committing statements afterwards. Rollback if there was an error
       try {
         await next();
         await self[sCloseConnections](closers, true);

--- a/lib/db/decorators/transaction.js
+++ b/lib/db/decorators/transaction.js
@@ -29,7 +29,7 @@ const ApplicationError = require('../../util/application_error');
  *
  *     &#64;mapping(Routes.GET, 'app');
  *     &#64;transaction // open all connections within this handler
- *     appHandler(ctx) {
+ *     async appHandler(ctx) {
  *       // ctx.transaction is an object containing
  *       // keys for DatabaseProviders and values
  *       // for their open connections
@@ -37,7 +37,7 @@ const ApplicationError = require('../../util/application_error');
  *
  *     &#64;mapping(Routes.GET, 'something');
  *     &#64;transaction('mysql', 'rethinkdb') // open one or more specific connections within this handler
- *     somethingHandler(ctx) {
+ *     async somethingHandler(ctx) {
  *       // can use ctx.transaction.mysql
  *       // can use ctx.transaction.rethinkdb
  *     }
@@ -52,7 +52,7 @@ const ApplicationError = require('../../util/application_error');
  *       super('/');
  *     }
  *
- *     post(ctx) {
+ *     async post(ctx) {
  *       // can use ctx.transaction.mysql
  *     }
  *   }

--- a/lib/ravel.js
+++ b/lib/ravel.js
@@ -169,14 +169,15 @@ class Ravel extends EventEmitter {
     //App dependencies.
     const http = require('http'); //https will be provided by reverse proxy
     const upath = require('upath');
-    const koa = require('koa');
+    const Koa = require('koa');
     const session = require('koa-generic-session');
     const compression = require('koa-compress');
     const favicon = require('koa-favicon');
-    const router = require('koa-router')();
+    const router = new (require('koa-router'))();
+    const koaConvert = require('koa-convert');
 
     // configure koa
-    const app = koa();
+    const app = new Koa();
     app.proxy = true;
 
     // the first piece of middleware is the exception handler
@@ -200,7 +201,7 @@ class Ravel extends EventEmitter {
     if (this.get('redis password')) {
       sessionStoreArgs.pass = this.get('redis password');
     }
-    app.use(session({
+    app.use(koaConvert(session({
       store: new (require('./util/redis_session_store'))(this),
       cookie: {
         path: '/',
@@ -209,7 +210,7 @@ class Ravel extends EventEmitter {
         rewrite: true,
         signed: true
       }
-    }));
+    })));
 
     // configure view engine
     if (this.get('koa view engine') && this.get('koa view directory')) {
@@ -228,10 +229,11 @@ class Ravel extends EventEmitter {
 
     // static file serving
     if (this.get('koa public directory')) {
+      const koaStatic = require('koa-static');
       const root = upath.join(this.cwd, this.get('koa public directory'));
-      app.use(require('koa-static')(root, {
+      app.use(koaConvert(koaStatic(root, {
         gzip: false // this should be handled by koa-compressor?
-      }));
+      })));
     }
 
     //initialize authentication/authentication
@@ -255,8 +257,9 @@ class Ravel extends EventEmitter {
 
     // include routes as middleware
     app.use(router.routes());
+    app.use(router.allowedMethods());
 
-    //Create koa server
+    // Create koa server
     this[sServer] = http.createServer(app.callback());
 
     // application configuration is completed

--- a/lib/util/rest.js
+++ b/lib/util/rest.js
@@ -76,10 +76,9 @@ class Rest {
    * @api private
    */
   respond() {
-    const self = this;
-    return function*(next) {
-      yield next;
-      buildRestResponse(self[sRavelInstance], this.request, this.response, this.respondOptions);
+    return async (ctx, next) => {
+      await next;
+      buildRestResponse(this[sRavelInstance], ctx.request, ctx.response, ctx.respondOptions);
     };
   }
 
@@ -90,20 +89,19 @@ class Rest {
    * @api private
    */
   errorHandler() {
-    const self = this;
-    return function*(next) {
+    return async (ctx, next) => {
       try {
-        yield next;
+        await next;
       } catch (err) {
         // always overwrite body with error message
-        this.response.type = 'text/plain; charset=utf-8';
-        if (err instanceof self[sRavelInstance].ApplicationError.General) {
-          this.response.status = err.code;
-          this.response.body = err.message;
+        ctx.response.type = 'text/plain; charset=utf-8';
+        if (err instanceof this[sRavelInstance].ApplicationError.General) {
+          ctx.response.status = err.code;
+          ctx.response.body = err.message;
         } else {
-          self[sRavelInstance].log.trace(err.stack);
-          this.response.status = httpCodes.INTERNAL_SERVER_ERROR;
-          this.response.body = err.stack;
+          this[sRavelInstance].log.trace(err.stack);
+          ctx.response.status = httpCodes.INTERNAL_SERVER_ERROR;
+          ctx.response.body = err.stack;
         }
       }
     };

--- a/lib/util/rest.js
+++ b/lib/util/rest.js
@@ -77,7 +77,7 @@ class Rest {
    */
   respond() {
     return async (ctx, next) => {
-      await next;
+      await next();
       buildRestResponse(this[sRavelInstance], ctx.request, ctx.response, ctx.respondOptions);
     };
   }
@@ -91,7 +91,7 @@ class Rest {
   errorHandler() {
     return async (ctx, next) => {
       try {
-        await next;
+        await next();
       } catch (err) {
         // always overwrite body with error message
         ctx.response.type = 'text/plain; charset=utf-8';

--- a/lib/util/rest.js
+++ b/lib/util/rest.js
@@ -70,9 +70,9 @@ class Rest {
    * which is exposed to clients for callback-building.
    *
    * @param {Object} options any extra data
-   * @return {Generator} Koa middleware which will yield to user logic, catch thrown errors,
-   *                     and respond with appropriate codes depending on the current verb or
-   *                     error. Status can be configured using ctx.respondOptions.okCode.
+   * @return {AsyncFunction} Koa middleware which will yield to user logic, catch thrown errors,
+   *                         and respond with appropriate codes depending on the current verb or
+   *                         error. Status can be configured using ctx.respondOptions.okCode.
    * @api private
    */
   respond() {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "koa-views": "5.2.0",
     "node-fs":"0.1.7",
     "passport": "0.3.2",
+    "path-to-regexp": "1.7.0",
     "redis":"2.6.3",
     "upath": "0.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "upath": "0.2.0"
   },
   "devDependencies": {
-    "async":"2.1.2",
+    "async":"2.1.4",
     "chai":"3.5.0",
     "chai-as-promised":"6.0.0",
     "chai-things":"0.2.0",
@@ -72,7 +72,7 @@
     "sinon":"1.17.6",
     "sinon-chai":"2.8.0",
     "supertest":"2.0.1",
-    "eslint": "3.10.2",
+    "eslint": "3.11.0",
 
     "codeclimate-test-reporter": "0.4.0",
     "del": "2.2.2",
@@ -86,10 +86,11 @@
     "gulp-open": "2.0.0",
 
     "gulp-sourcemaps": "1.9.1",
-    "gulp-typescript": "3.1.3",
-    "typescript": "2.0.10",
     "source-map-support": "0.4.6",
-    "typescript-eslint-parser": "1.0.0",
-    "eslint-plugin-typescript": "0.1.0"
+    "gulp-babel":"6.1.2",
+    "babel-core":"6.18.2",
+    "babel-eslint": "7.1.1",
+    "babel-plugin-transform-async-to-generator": "6.16.0",
+    "babel-plugin-transform-decorators-legacy": "1.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravel",
-  "version": "0.17.20",
+  "version": "0.18.0",
   "author": "Sean McIntyre <s.mcintyre@xverba.ca>",
   "description": "Ravel Rapid Application Development Framework",
   "engines": {
@@ -33,23 +33,22 @@
     "clean": "gulp clean",
     "docs":"gulp docs",
     "watch":"gulp watch",
-    "test":"gulp --require source-map-support/register test",
-    "test-no-cov":"gulp --require source-map-support/register test-no-cov",
+    "test":"node --harmony_async_await $(which gulp) --require source-map-support/register test",
+    "test-no-cov":"node --harmony_async_await $(which gulp) --require source-map-support/register test-no-cov",
     "show-coverage":"gulp show-coverage",
-    "debug":"node debug $(which gulp) --require source-map-support/register test-no-cov",
-    "debug-remote":"node --debug-brk=5858 $(which gulp) --require source-map-support/register test-no-cov"
+    "debug":"node  --harmony_async_await debug $(which gulp) --require source-map-support/register test-no-cov",
+    "debug-remote":"node  --harmony_async_await --debug-brk=5858 $(which gulp) --require source-map-support/register test-no-cov"
   },
   "dependencies": {
-    "co":"4.6.0",
     "fs-readdir-recursive":"1.0.0",
     "intel":"1.1.1",
-    "koa": "1.2.4",
-    "koa-compress": "1.0.9",
-    "koa-compose":"2.5.1",
-    "koa-favicon": "1.2.1",
+    "koa": "2.0.0-alpha.7",
+    "koa-compress": "2.0.0",
+    "koa-convert": "1.2.0",
+    "koa-favicon": "2.0.0",
     "koa-generic-session": "1.11.3",
-    "koa-passport": "1.3.1",
-    "koa-router": "5.4.0",
+    "koa-passport": "2.2.2",
+    "koa-router": "7.0.1",
     "koa-static": "2.0.0",
     "koa-views": "5.2.0",
     "node-fs":"0.1.7",
@@ -71,8 +70,8 @@
     "redis-mock":"0.16.0",
     "sinon":"1.17.6",
     "sinon-chai":"2.8.0",
-    "supertest":"2.0.1",
     "eslint": "3.11.0",
+    "supertest":"2.0.1",
 
     "codeclimate-test-reporter": "0.4.0",
     "del": "2.2.2",
@@ -90,7 +89,6 @@
     "gulp-babel":"6.1.2",
     "babel-core":"6.18.2",
     "babel-eslint": "7.1.1",
-    "babel-plugin-transform-async-to-generator": "6.16.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,11 @@
     "clean": "gulp clean",
     "docs":"gulp docs",
     "watch":"gulp watch",
-    "test":"node --harmony_async_await $(which gulp) --require source-map-support/register test",
+    "test":"node $(which gulp) --require source-map-support/register test",
     "test-no-cov":"node --harmony_async_await $(which gulp) --require source-map-support/register test-no-cov",
     "show-coverage":"gulp show-coverage",
-    "debug":"node  --harmony_async_await debug $(which gulp) --require source-map-support/register test-no-cov",
-    "debug-remote":"node  --harmony_async_await --debug-brk=5858 $(which gulp) --require source-map-support/register test-no-cov"
+    "debug":"node --harmony_async_await debug $(which gulp) --require source-map-support/register test-no-cov",
+    "debug-remote":"node --harmony_async_await --debug-brk=5858 $(which gulp) --require source-map-support/register test-no-cov"
   },
   "dependencies": {
     "fs-readdir-recursive":"1.0.0",
@@ -90,6 +90,7 @@
     "gulp-babel":"6.1.2",
     "babel-core":"6.18.2",
     "babel-eslint": "7.1.1",
+    "babel-plugin-transform-async-to-generator": "6.16.0",
     "babel-plugin-transform-decorators-legacy": "1.3.4"
   }
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,10 +1,6 @@
 {
   "extends": "../.eslintrc.json",
-  /*"parser": "babel-eslint",*/
-  "parser": "typescript-eslint-parser",
-  "plugins": [
-    "typescript"
-  ],
+  "parser": "babel-eslint",
   "globals": {
     "describe":   false,
     "before":     false,
@@ -18,7 +14,5 @@
   "env": {
     "mocha": true
   },
-  "rules":  {
-    "no-unused-vars": 0
-  }
+  "rules":  {}
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,6 +1,5 @@
 {
   "extends": "../.eslintrc.json",
-  "parser": "babel-eslint",
   "globals": {
     "describe":   false,
     "before":     false,

--- a/test/auth/decorators/test-authenticated.js
+++ b/test/auth/decorators/test-authenticated.js
@@ -91,7 +91,7 @@ describe('Routes', function() {
     });
 
     describe('auth middleware insertion', function() {
-      const authenticationMiddleware = function*(next){ yield next; };
+      const authenticationMiddleware = async function(ctx, next){ await next; };
       let Ravel, Routes, coreSymbols;
 
       beforeEach((done) => {

--- a/test/auth/decorators/test-authenticated.js
+++ b/test/auth/decorators/test-authenticated.js
@@ -91,7 +91,7 @@ describe('Routes', function() {
     });
 
     describe('auth middleware insertion', function() {
-      const authenticationMiddleware = async function(ctx, next){ await next; };
+      const authenticationMiddleware = async function(ctx, next){ await next(); };
       let Ravel, Routes, coreSymbols;
 
       beforeEach((done) => {

--- a/test/auth/test-authenticate-request.js
+++ b/test/auth/test-authenticate-request.js
@@ -7,7 +7,7 @@ chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
 const sinon = require('sinon');
 const mockery = require('mockery');
-const koa = require('koa');
+const Koa = require('koa');
 const request = require('supertest');
 const upath = require('upath');
 
@@ -49,7 +49,7 @@ describe('util/authenticate_request', function() {
     const Rest = require('../../lib/util/rest');
     restMiddleware = (new Rest(Ravel)).errorHandler();
     Ravel.log.setLevel('NONE');
-    app = koa();
+    app = new Koa();
     Ravel.kvstore = {}; // mock Ravel.kvstore, since we're not actually starting Ravel.
     Ravel[coreSymbols.parametersLoaded] = true;
     done();
@@ -81,14 +81,14 @@ describe('util/authenticate_request', function() {
       done();
     });
 
-    it('should use passport\'s req.isAuthenticated() to check users by default, yielding to next() if users are authenticated by passport', (done) => {
+    it('should use passport\'s req.isAuthenticated() to check users by default, awaiting next() if users are authenticated by passport', (done) => {
       const isAuthenticatedStub = sinon.stub().returns(true);
       const finalStub = sinon.stub();
 
       app.use(restMiddleware);
       app.use(async function(ctx, next) {
         ctx.isAuthenticated = isAuthenticatedStub;
-        await next;
+        await next();
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
       app.use(function() {
@@ -109,8 +109,8 @@ describe('util/authenticate_request', function() {
 
       app.use(restMiddleware);
       app.use(async function(ctx, next) {
-        this.isAuthenticated = isAuthenticatedStub;
-        await next;
+        ctx.isAuthenticated = isAuthenticatedStub;
+        await next();
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
 
@@ -128,8 +128,8 @@ describe('util/authenticate_request', function() {
 
       app.use(restMiddleware);
       app.use(async function(ctx, next) {
-        this.isAuthenticated = isAuthenticatedStub;
-        await next;
+        ctx.isAuthenticated = isAuthenticatedStub;
+        await next();
       });
       app.use((new AuthenticationMiddleware(Ravel, true, false)).middleware());
 
@@ -168,8 +168,8 @@ describe('util/authenticate_request', function() {
 
       app.use(restMiddleware);
       app.use(async function(ctx, next) {
-        this.isAuthenticated = isAuthenticatedStub;
-        await next;
+        ctx.isAuthenticated = isAuthenticatedStub;
+        await next();
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
       app.use(async function(ctx) {
@@ -215,8 +215,8 @@ describe('util/authenticate_request', function() {
 
       app.use(restMiddleware);
       app.use(async function(ctx, next) {
-        this.isAuthenticated = isAuthenticatedStub;
-        await next;
+        ctx.isAuthenticated = isAuthenticatedStub;
+        await next();
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
       app.use(async function() {
@@ -247,7 +247,7 @@ describe('util/authenticate_request', function() {
       app.use(restMiddleware);
       app.use(async function(ctx, next) {
         ctx.isAuthenticated = isAuthenticatedStub;
-        await next;
+        await next();
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
       app.use(function() {
@@ -292,7 +292,7 @@ describe('util/authenticate_request', function() {
       app.use(restMiddleware);
       app.use(async function(ctx,  next) {
         ctx.isAuthenticated = isAuthenticatedStub;
-        await next;
+        await next();
       });
       app.use((new AuthenticationMiddleware(Ravel, false, true)).middleware());
       app.use(async function(ctx) {
@@ -338,7 +338,7 @@ describe('util/authenticate_request', function() {
       app.use(restMiddleware);
       app.use(async function(ctx, next) {
         ctx.isAuthenticated = isAuthenticatedStub;
-        await next;
+        await next();
       });
       app.use((new AuthenticationMiddleware(Ravel, false, true)).middleware());
       app.use(async function(ctx) {
@@ -366,7 +366,7 @@ describe('util/authenticate_request', function() {
       app.use(async function(ctx, next) {
         ctx.isAuthenticated = isAuthenticatedStub;
         try {
-          await next;
+          await next();
           ctx.status = 200;
         } catch (err) {
           expect(err).to.equal(error);

--- a/test/auth/test-authenticate-request.js
+++ b/test/auth/test-authenticate-request.js
@@ -86,12 +86,12 @@ describe('util/authenticate_request', function() {
       const finalStub = sinon.stub();
 
       app.use(restMiddleware);
-      app.use(function*(next) {
-        this.isAuthenticated = isAuthenticatedStub;
-        yield next;
+      app.use(async function(ctx, next) {
+        ctx.isAuthenticated = isAuthenticatedStub;
+        await next;
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
-      app.use(function*() {
+      app.use(function() {
         finalStub();
       });
 
@@ -108,9 +108,9 @@ describe('util/authenticate_request', function() {
       const isAuthenticatedStub = sinon.stub().returns(false);
 
       app.use(restMiddleware);
-      app.use(function*(next) {
+      app.use(async function(ctx, next) {
         this.isAuthenticated = isAuthenticatedStub;
-        yield next;
+        await next;
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
 
@@ -127,9 +127,9 @@ describe('util/authenticate_request', function() {
       const isAuthenticatedStub = sinon.stub().returns(false);
 
       app.use(restMiddleware);
-      app.use(function*(next) {
+      app.use(async function(ctx, next) {
         this.isAuthenticated = isAuthenticatedStub;
-        yield next;
+        await next;
       });
       app.use((new AuthenticationMiddleware(Ravel, true, false)).middleware());
 
@@ -167,13 +167,13 @@ describe('util/authenticate_request', function() {
       Ravel.emit('post module init');
 
       app.use(restMiddleware);
-      app.use(function*(next) {
+      app.use(async function(ctx, next) {
         this.isAuthenticated = isAuthenticatedStub;
-        yield next;
+        await next;
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
-      app.use(function*() {
-        expect(this).to.have.property('user').that.equals(user);
+      app.use(async function(ctx) {
+        expect(ctx).to.have.property('user').that.equals(user);
         finalStub();
       });
 
@@ -214,12 +214,12 @@ describe('util/authenticate_request', function() {
       Ravel.emit('post module init');
 
       app.use(restMiddleware);
-      app.use(function*(next) {
+      app.use(async function(ctx, next) {
         this.isAuthenticated = isAuthenticatedStub;
-        yield next;
+        await next;
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
-      app.use(function*() {
+      app.use(async function() {
         finalStub();
       });
 
@@ -245,12 +245,12 @@ describe('util/authenticate_request', function() {
       });
 
       app.use(restMiddleware);
-      app.use(function*(next) {
-        this.isAuthenticated = isAuthenticatedStub;
-        yield next;
+      app.use(async function(ctx, next) {
+        ctx.isAuthenticated = isAuthenticatedStub;
+        await next;
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
-      app.use(function*() {
+      app.use(function() {
         finalStub();
       });
 
@@ -290,13 +290,13 @@ describe('util/authenticate_request', function() {
       Ravel.emit('post module init');
 
       app.use(restMiddleware);
-      app.use(function*(next) {
-        this.isAuthenticated = isAuthenticatedStub;
-        yield next;
+      app.use(async function(ctx,  next) {
+        ctx.isAuthenticated = isAuthenticatedStub;
+        await next;
       });
       app.use((new AuthenticationMiddleware(Ravel, false, true)).middleware());
-      app.use(function*() {
-        expect(this).to.have.property('user').that.equals(user);
+      app.use(async function(ctx) {
+        expect(ctx).to.have.property('user').that.equals(user);
         finalStub();
       });
 
@@ -336,14 +336,14 @@ describe('util/authenticate_request', function() {
       Ravel.emit('post module init');
 
       app.use(restMiddleware);
-      app.use(function*(next) {
-        this.isAuthenticated = isAuthenticatedStub;
-        yield next;
+      app.use(async function(ctx, next) {
+        ctx.isAuthenticated = isAuthenticatedStub;
+        await next;
       });
       app.use((new AuthenticationMiddleware(Ravel, false, true)).middleware());
-      app.use(function*() {
+      app.use(async function(ctx) {
         // this assertion would fail if this middleware ever ran. But it shouldn't run.
-        expect(this).to.have.property('user').that.equals(user);
+        expect(ctx).to.have.property('user').that.equals(user);
         finalStub();
       });
 
@@ -363,24 +363,24 @@ describe('util/authenticate_request', function() {
       const error = new Error('something went wrong');
 
       app.use(restMiddleware);
-      app.use(function*(next) {
-        this.isAuthenticated = isAuthenticatedStub;
+      app.use(async function(ctx, next) {
+        ctx.isAuthenticated = isAuthenticatedStub;
         try {
-          yield next;
-          this.status = 200;
+          await next;
+          ctx.status = 200;
         } catch (err) {
           expect(err).to.equal(error);
-          this.body = 'something went wrong';
-          this.status = 500;
+          ctx.body = 'something went wrong';
+          ctx.status = 500;
         }
       });
       app.use((new AuthenticationMiddleware(Ravel, false, false)).middleware());
-      app.use(function*() {
+      app.use(async function() {
         throw error;
       });
       request(app.callback())
       .get('/entity')
-      .expect(function() {
+      .expect(async function() {
         expect(isAuthenticatedStub).to.have.been.called;
       })
       .expect(500, 'something went wrong', done);

--- a/test/auth/test-passport-init.js
+++ b/test/auth/test-passport-init.js
@@ -7,7 +7,7 @@ chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
 const mockery = require('mockery');
 const sinon = require('sinon');
-const koa = require('koa');
+const Koa = require('koa');
 const upath = require('upath');
 
 const AuthenticationProvider = (require('../../lib/ravel')).AuthenticationProvider;
@@ -65,7 +65,7 @@ describe('auth/passport_init', function() {
   });
 
   it('should not initialize passport if no authentication providers are registered', (done) => {
-    const app = koa();
+    const app = new Koa();
     const passportInitSpy = sinon.spy(passportMock, 'initialize');
     const passportSessionSpy = sinon.spy(passportMock, 'session');
 
@@ -100,7 +100,7 @@ describe('auth/passport_init', function() {
     const provider = new GoogleOAuth2(ravelApp);
     provider.init = sinon.stub();
 
-    const app = koa();
+    const app = new Koa();
     const useSpy = sinon.spy(app, 'use');
     const passportInitSpy = sinon.spy(passportMock, 'initialize');
     const passportSessionSpy = sinon.spy(passportMock, 'session');
@@ -123,7 +123,7 @@ describe('auth/passport_init', function() {
     provider.init = sinon.stub();
     require('../../lib/auth/passport_init')(ravelApp, {});
 
-    const app = koa();
+    const app = new Koa();
     function test() {
       ravelApp.emit('post config koa', app);
       ravelApp.emit('post module init');
@@ -153,7 +153,7 @@ describe('auth/passport_init', function() {
     provider.init = sinon.stub();
 
     require('../../lib/auth/passport_init')(ravelApp);
-    const app = koa();
+    const app = new Koa();
 
     sinon.stub(passportMock, 'serializeUser', function(serializerFn) {
       serializerFn({id:9876}, function(err, result) {
@@ -193,7 +193,7 @@ describe('auth/passport_init', function() {
     provider.init = sinon.stub();
 
     require('../../lib/auth/passport_init')(ravelApp);
-    const app = koa();
+    const app = new Koa();
 
     sinon.stub(passportMock, 'deserializeUser', function(deserializerFn) {
       deserializerFn(9876, function(err, result) {
@@ -235,7 +235,7 @@ describe('auth/passport_init', function() {
     provider.init = sinon.stub();
 
     require('../../lib/auth/passport_init')(ravelApp);
-    const app = koa();
+    const app = new Koa();
 
     sinon.stub(passportMock, 'serializeUser', function(serializerFn) {
       serializerFn(9876, function(err, result) {
@@ -279,7 +279,7 @@ describe('auth/passport_init', function() {
     provider.init = sinon.stub();
 
     require('../../lib/auth/passport_init')(ravelApp);
-    const app = koa();
+    const app = new Koa();
 
     sinon.stub(passportMock, 'deserializeUser', function(deserializerFn) {
       deserializerFn(9876, function(err, result) {
@@ -319,7 +319,7 @@ describe('auth/passport_init', function() {
     });
 
     require('../../lib/auth/passport_init')(ravelApp);
-    const app = koa();
+    const app = new Koa();
 
     ravelApp.emit('post config koa', app);
     ravelApp[coreSymbols.moduleInit]();
@@ -347,7 +347,7 @@ describe('auth/passport_init', function() {
     });
 
     require('../../lib/auth/passport_init')(ravelApp);
-    const app = koa();
+    const app = new Koa();
 
     ravelApp.emit('post config koa', app);
     ravelApp[coreSymbols.moduleInit]();

--- a/test/auth/test-passport-init.js
+++ b/test/auth/test-passport-init.js
@@ -28,6 +28,7 @@ describe('auth/passport_init', function() {
       warnOnUnregistered: false
     });
 
+    // koa-passport still uses generators!
     passportMock = {
       initialize: function() {
         return function*(next) {

--- a/test/auth/test-passport-init.js
+++ b/test/auth/test-passport-init.js
@@ -17,7 +17,7 @@ class GoogleOAuth2 extends AuthenticationProvider {
   }
 }
 
-let Ravel, ravelApp, lib, authconfig, passportMock, coreSymbols;
+let Ravel, ravelApp, authconfig, passportMock, coreSymbols;
 
 describe('auth/passport_init', function() {
   beforeEach((done) => {

--- a/test/core/test-module.js
+++ b/test/core/test-module.js
@@ -90,7 +90,7 @@ describe('Ravel', function() {
       Ravel.db = {
         scoped: scopedStub
       };
-      const gen = function*() {};
+      const gen = async function() {};
 
       const another = {};
       mockery.registerMock('another', another);

--- a/test/core/test-reflect.js
+++ b/test/core/test-reflect.js
@@ -77,7 +77,7 @@ describe('Ravel', function() {
 
         @mapping(Routes.PUT, '/path')
         @before('middleware2')
-        *pathHandler(ctx) {
+        async pathHandler(ctx) {
           ctx.status = 200;
         }
       };
@@ -128,7 +128,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware2')
-        *get(ctx) {
+        async get(ctx) {
           ctx.status = 200;
         }
       };
@@ -221,7 +221,7 @@ describe('Ravel', function() {
 
         @mapping(Routes.PUT, '/path')
         @before('middleware2')
-        *pathHandler(ctx) {
+        async pathHandler(ctx) {
           ctx.status = 200;
         }
       };

--- a/test/core/test-reflect.js
+++ b/test/core/test-reflect.js
@@ -116,8 +116,8 @@ describe('Ravel', function() {
     });
 
     it('should allow clients to retrieve metadata from Resources', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
       const Resource = Ravel.Resource;
       const before = Resource.before;
 
@@ -136,7 +136,7 @@ describe('Ravel', function() {
       mockery.registerMock('middleware1', middleware1);
       mockery.registerMock('middleware2', middleware2);
       app.db = { // mock app.db
-        middleware: function*(next){ yield next;}
+        middleware: async function(ctx, next){ await next;}
       };
 
       // need to call init so that it creates @mapping decorators

--- a/test/core/test-reflect.js
+++ b/test/core/test-reflect.js
@@ -116,8 +116,8 @@ describe('Ravel', function() {
     });
 
     it('should allow clients to retrieve metadata from Resources', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
       const Resource = Ravel.Resource;
       const before = Resource.before;
 
@@ -136,7 +136,7 @@ describe('Ravel', function() {
       mockery.registerMock('middleware1', middleware1);
       mockery.registerMock('middleware2', middleware2);
       app.db = { // mock app.db
-        middleware: async function(ctx, next){ await next;}
+        middleware: async function(ctx, next){ await next();}
       };
 
       // need to call init so that it creates @mapping decorators

--- a/test/core/test-resource.js
+++ b/test/core/test-resource.js
@@ -155,8 +155,8 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of GET routes via $Resource.getAll', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {
@@ -183,8 +183,8 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of GET routes via $Resource.get', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {
@@ -212,8 +212,8 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of POST routes via $Resource.post', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {
@@ -241,8 +241,8 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of PUT routes via $Resource.put', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {
@@ -270,8 +270,8 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of PUT routes via $Resource.putAll', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {
@@ -299,8 +299,8 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of DELETE routes via $Resource.deleteAll', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {
@@ -328,8 +328,8 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of DELETE routes via $Resource.delete', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {
@@ -357,8 +357,8 @@ describe('Ravel', function() {
     });
 
     it('should support the use of @before at the class level', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       @before('middleware1')
       class Stub extends Resource {
@@ -387,8 +387,8 @@ describe('Ravel', function() {
     });
 
     it('should support the use of @before on some, but not all, endpoints', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {
@@ -494,8 +494,8 @@ describe('Ravel', function() {
 
   describe('Resource Integration Test', function() {
     it('should integrate properly with koa and koa-router', (done) => {
-      const middleware1 = async function(ctx, next) { await next; };
-      const middleware2 = async function(ctx, next) { await next; };
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Resource {
         constructor() {

--- a/test/core/test-resource.js
+++ b/test/core/test-resource.js
@@ -164,7 +164,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *getAll() {
+        async getAll() {
         }
       }
       const router = require('koa-router')();
@@ -194,7 +194,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *get() {
+        async get() {
         }
       }
       const router = require('koa-router')();
@@ -221,7 +221,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *post() {
+        async post() {
         }
       }
       const router = require('koa-router')();
@@ -252,7 +252,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *put() {
+        async put() {
         }
       }
       const router = require('koa-router')();
@@ -279,7 +279,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *putAll() {
+        async putAll() {
         }
       }
       const router = require('koa-router')();
@@ -310,7 +310,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *deleteAll() {
+        async deleteAll() {
         }
       }
       const router = require('koa-router')();
@@ -337,7 +337,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *delete() {
+        async delete() {
         }
       }
       const router = require('koa-router')();
@@ -369,7 +369,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware2')
-        *get() {
+        async get() {
         }
       }
       const router = require('koa-router')();
@@ -398,10 +398,10 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *get() {
+        async get() {
         }
 
-        *put() {
+        async put() {
         }
       }
       const router = require('koa-router')();
@@ -456,7 +456,7 @@ describe('Ravel', function() {
         constructor() {
           super('/api/test');
         }
-        *getAll() {
+        async getAll() {
         }
       }
       const router = require('koa-router')();
@@ -505,7 +505,7 @@ describe('Ravel', function() {
         }
 
         @before('middleware1', 'middleware2')
-        *get(ctx) {
+        async get(ctx) {
           ctx.body = ctx.params;
         }
       }

--- a/test/core/test-resource.js
+++ b/test/core/test-resource.js
@@ -9,7 +9,7 @@ const mockery = require('mockery');
 const upath = require('upath');
 const sinon = require('sinon');
 const request = require('supertest');
-const koa = require('koa');
+const Koa = require('koa');
 
 let Ravel, Resource, before, inject, coreSymbols;
 
@@ -155,8 +155,8 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of GET routes via $Resource.getAll', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -178,13 +178,13 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
     it('should facilitate the creation of GET routes via $Resource.get', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -207,13 +207,13 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
     it('should facilitate the creation of POST routes via $Resource.post', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -236,13 +236,13 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
     it('should facilitate the creation of PUT routes via $Resource.put', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -265,13 +265,13 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
     it('should facilitate the creation of PUT routes via $Resource.putAll', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -294,13 +294,13 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
     it('should facilitate the creation of DELETE routes via $Resource.deleteAll', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -323,13 +323,13 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
     it('should facilitate the creation of DELETE routes via $Resource.delete', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -352,13 +352,13 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
     it('should support the use of @before at the class level', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       @before('middleware1')
       class Stub extends Resource {
@@ -382,13 +382,13 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
     it('should support the use of @before on some, but not all, endpoints', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -415,11 +415,11 @@ describe('Ravel', function() {
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
         middleware1,
         middleware2,
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       expect(spy2).to.have.been.calledWith(
         '/api/test/:id',
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
@@ -467,7 +467,7 @@ describe('Ravel', function() {
       expect(spy).to.have.been.calledWith(
         '/api/test',
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
 
@@ -487,15 +487,15 @@ describe('Ravel', function() {
       expect(spy).to.have.been.calledWith(
         '/api/test',
         sinon.match((v) => typeof v === 'function' && v.toString().indexOf('buildRestResponse') > 0),
-        sinon.match((value) => value.constructor.name === 'GeneratorFunction'));
+        sinon.match((value) => value.constructor.name === 'AsyncFunction'));
       done();
     });
   });
 
   describe('Resource Integration Test', function() {
     it('should integrate properly with koa and koa-router', (done) => {
-      const middleware1 = function*(next) { yield next; };
-      const middleware2 = function*(next) { yield next; };
+      const middleware1 = async function(ctx, next) { await next; };
+      const middleware2 = async function(ctx, next) { await next; };
 
       class Stub extends Resource {
         constructor() {
@@ -509,8 +509,8 @@ describe('Ravel', function() {
           ctx.body = ctx.params;
         }
       }
-      const router = require('koa-router')();
-      const app = koa();
+      const router = new (require('koa-router'))();
+      const app = new Koa();
 
       mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
       Ravel.resource('test');

--- a/test/core/test-routes.js
+++ b/test/core/test-routes.js
@@ -5,9 +5,9 @@ const expect = chai.expect;
 chai.use(require('chai-things'));
 const mockery = require('mockery');
 const upath = require('upath');
-const sinon = require('sinon');
 const request = require('supertest');
 const async = require('async');
+const Koa = require('koa');
 
 let Ravel, Routes, inject, mapping, before, coreSymbols;
 
@@ -151,219 +151,204 @@ describe('Ravel', function() {
     });
 
     it('should facilitate the creation of GET routes via @mapping', (done) => {
-      const middleware1 = function(/*req, res*/) {};
-      const middleware2 = function(/*req, res*/) {};
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Routes {
         constructor() {
-          super('/app');
+          super('/api');
+          this.middleware1 = middleware1;
+          this.middleware2 = middleware2;
         }
 
-        @mapping(Routes.GET, '/path')
+        @mapping(Routes.GET, '/test')
         @before('middleware1','middleware2')
         async pathHandler(ctx) {
           ctx.status = 200;
+          ctx.body = {id: 3};
         }
       };
-      mockery.registerMock(upath.join(Ravel.cwd, 'stub'), Stub);
-      mockery.registerMock('middleware1', middleware1);
-      mockery.registerMock('middleware2', middleware2);
-      Ravel.routes('stub');
+      const router = new (require('koa-router'))();
+      const app = new Koa();
 
-      //load up koa
-      const router = require('koa-router')();
-      sinon.stub(router, 'get', function() {
-        expect(arguments[0]).to.equal('/app/path');
-        expect(arguments[1]).to.be.a.function; // respond middleware
-        expect(arguments[1].toString()).to.include('buildRestResponse');
-        expect(arguments[2]).to.equal(middleware1);
-        expect(arguments[3]).to.equal(middleware2);
-        done();
-      });
+      mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
+      Ravel.routes('test');
       Ravel[coreSymbols.routesInit](router);
+
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+
+      request(app.callback())
+      .get('/api/test')
+      .expect(200, {id: 3}, done);
     });
 
     it('should facilitate the creation of POST routes via @mapping', (done) => {
-      const middleware1 = function(/*req, res*/) {};
-      const middleware2 = function(/*req, res*/) {};
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
+      const body = {id: 1};
 
       class Stub extends Routes {
         constructor() {
-          super('/app');
+          super('/api');
+          this.middleware1 = middleware1;
+          this.middleware2 = middleware2;
         }
 
-        @mapping(Routes.POST, '/path')
+        @mapping(Routes.POST, '/test')
         @before('middleware1','middleware2')
         async pathHandler(ctx) {
           ctx.status = 200;
+          ctx.body = body;
         }
       };
-      mockery.registerMock(upath.join(Ravel.cwd, 'stub'), Stub);
-      mockery.registerMock('middleware1', middleware1);
-      mockery.registerMock('middleware2', middleware2);
-      Ravel.routes('stub');
+      const router = new (require('koa-router'))();
+      const app = new Koa();
 
-      //load up koa
-      const router = require('koa-router')();
-      sinon.stub(router, 'post', function() {
-        expect(arguments[0]).to.equal('/app/path');
-        expect(arguments[1]).to.be.a.function; // respond middleware
-        expect(arguments[2]).to.equal(middleware1);
-        expect(arguments[3]).to.equal(middleware2);
-        done();
-      });
+      mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
+      Ravel.routes('test');
       Ravel[coreSymbols.routesInit](router);
+
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+
+      request(app.callback())
+      .post('/api/test')
+      .expect(201, body, done);
     });
 
     it('should facilitate the creation of PUT routes via @mapping', (done) => {
-      const middleware1 = function(/*req, res*/) {};
-      const middleware2 = function(/*req, res*/) {};
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Routes {
         constructor() {
-          super('/app');
+          super('/api');
+          this.middleware1 = middleware1;
+          this.middleware2 = middleware2;
         }
 
-        @mapping(Routes.PUT, '/path')
+        @mapping(Routes.PUT, '/test')
         @before('middleware1','middleware2')
         async pathHandler(ctx) {
-          ctx.status = 200;
+          ctx.body = {id: 1};
         }
       };
-      mockery.registerMock(upath.join(Ravel.cwd, 'stub'), Stub);
-      mockery.registerMock('middleware1', middleware1);
-      mockery.registerMock('middleware2', middleware2);
-      Ravel.routes('stub');
+      const router = new (require('koa-router'))();
+      const app = new Koa();
 
-      //load up koa
-      const router = require('koa-router')();
-      sinon.stub(router, 'put', function() {
-        expect(arguments[0]).to.equal('/app/path');
-        expect(arguments[1]).to.be.a.function; // respond middleware
-        expect(arguments[1].toString()).to.include('buildRestResponse');
-        expect(arguments[2]).to.equal(middleware1);
-        expect(arguments[3]).to.equal(middleware2);
-        done();
-      });
+      mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
+      Ravel.routes('test');
       Ravel[coreSymbols.routesInit](router);
+
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+
+      request(app.callback())
+      .put('/api/test')
+      .expect(200, {id: 1}, done);
     });
 
     it('should facilitate the creation of DELETE routes via @mapping', (done) => {
-      const middleware1 = function(/*req, res*/) {};
-      const middleware2 = function(/*req, res*/) {};
+      const middleware1 = async function(ctx, next) { await next(); };
+      const middleware2 = async function(ctx, next) { await next(); };
 
       class Stub extends Routes {
         constructor() {
-          super('/app');
+          super('/api');
+          this.middleware1 = middleware1;
+          this.middleware2 = middleware2;
         }
 
-        @mapping(Routes.DELETE, '/path')
+        @mapping(Routes.DELETE, '/test')
         @before('middleware1','middleware2')
         async pathHandler(ctx) {
-          ctx.status = 200;
+          ctx.body = {id: 1};
         }
       };
-      mockery.registerMock(upath.join(Ravel.cwd, 'stub'), Stub);
-      mockery.registerMock('middleware1', middleware1);
-      mockery.registerMock('middleware2', middleware2);
-      Ravel.routes('stub');
+      const router = new (require('koa-router'))();
+      const app = new Koa();
 
-      //load up koa
-      const router = require('koa-router')();
-      sinon.stub(router, 'delete', function() {
-        expect(arguments[0]).to.equal('/app/path');
-        expect(arguments[1]).to.be.a.function; // respond middleware
-        expect(arguments[1].toString()).to.include('buildRestResponse');
-        expect(arguments[2]).to.equal(middleware1);
-        expect(arguments[3]).to.equal(middleware2);
-        done();
-      });
+      mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
+      Ravel.routes('test');
       Ravel[coreSymbols.routesInit](router);
+
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+
+      request(app.callback())
+      .delete('/api/test')
+      .expect(200, {id: 1}, done);
     });
 
-    it('should support the use of @before at the class level as well', (done) => {
-      const middleware1 = function(/*req, res*/) {};
-      const middleware2 = function(/*req, res*/) {};
+    it('should support the use of @before at the method and class levels', (done) => {
+      const middleware1 = async function(ctx, next) { ctx.body = {id: ctx.params.id}; await next(); };
+      const middleware2 = async function(ctx, next) { ctx.body.name = 'sean'; await next(); };
 
       @before('middleware1')
       class Stub extends Routes {
         constructor() {
-          super('/app');
+          super('/api');
+          this.middleware1 = middleware1;
+          this.middleware2 = middleware2;
         }
 
-        @mapping(Routes.GET, '/path')
+        @mapping(Routes.GET, '/test/:id')
         @before('middleware2')
         async pathHandler(ctx) {
-          ctx.status(200);
+          ctx.status = 200;
         }
       };
-      mockery.registerMock(upath.join(Ravel.cwd, 'stub'), Stub);
-      mockery.registerMock('middleware1', middleware1);
-      mockery.registerMock('middleware2', middleware2);
-      Ravel.routes('stub');
+      const router = new (require('koa-router'))();
+      const app = new Koa();
 
-      //load up koa
-      const router = require('koa-router')();
-      sinon.stub(router, 'get', function() {
-        expect(arguments[0]).to.equal('/app/path');
-        expect(arguments[1]).to.be.a.function; // respond middleware
-        expect(arguments[1].toString()).to.include('buildRestResponse');
-        expect(arguments[2]).to.equal(middleware1);
-        expect(arguments[3]).to.equal(middleware2);
-        done();
-      });
-      sinon.stub(router, 'post', function() {
-        done(new Error('Routes class should never use app.post.'));
-      });
-      sinon.stub(router, 'put', function() {
-        done(new Error('Routes class should never use app.put.'));
-      });
-      sinon.stub(router, 'delete', function() {
-        done(new Error('Routes class should never use app.delete.'));
-      });
+      mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
+      Ravel.routes('test');
       Ravel[coreSymbols.routesInit](router);
+
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+
+      request(app.callback())
+      .get('/api/test/3')
+      .expect(200, {id: 3, name: 'sean'}, done);
     });
 
     it('should support the use of @mapping without @before', (done) => {
       class Stub extends Routes {
         constructor() {
-          super('/app');
+          super('/api');
         }
 
-        @mapping(Routes.GET, '/path')
+        @mapping(Routes.GET, '/test')
         async pathHandler(ctx) {
-          ctx.status(200);
+          ctx.status = 200;
+          ctx.body = {};
         }
 
         @before('middleware2') // this should just be ignored, since @mapping isn't present
         async ignoredHandler(ctx) {
-          ctx.status(200);
+          ctx.status = 200;
         }
       };
-      mockery.registerMock(upath.join(Ravel.cwd, 'stub'), Stub);
-      Ravel.routes('stub');
+      const router = new (require('koa-router'))();
+      const app = new Koa();
 
-      //load up koa
-      const router = require('koa-router')();
-      sinon.stub(router, 'get', function() {
-        expect(arguments[0]).to.equal('/app/path');
-        done();
-      });
-      sinon.stub(router, 'post', function() {
-        done(new Error('Routes class should never use app.post.'));
-      });
-      sinon.stub(router, 'put', function() {
-        done(new Error('Routes class should never use app.put.'));
-      });
-      sinon.stub(router, 'delete', function() {
-        done(new Error('Routes class should never use app.delete.'));
-      });
+      mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
+      Ravel.routes('test');
       Ravel[coreSymbols.routesInit](router);
+
+      app.use(router.routes());
+      app.use(router.allowedMethods());
+
+      request(app.callback())
+      .get('/api/test')
+      .expect(200, {}, done);
     });
 
     it('should support the use of @mapping at the class level as well, to denote unsupported routes', (done) => {
-      @mapping(Routes.GET, '/path') // will respond with NOT_IMPLEMENTED
-      @mapping(Routes.POST, '/another', 404) // will respond with 404
+      @mapping(Routes.GET, '/path') // should respond with NOT_IMPLEMENTED
+      @mapping(Routes.POST, '/another', 404) // should respond with 404
       class Stub extends Routes {
         constructor() {
           super('/app');
@@ -385,5 +370,38 @@ describe('Ravel', function() {
         function(next) {agent.post('/app/another').expect(404).end(next);}
       ], done);
     });
+  });
+
+  it('should support non-async handlers as well', (done) => {
+    const middleware1 = async function(ctx, next) { await next(); };
+    const middleware2 = async function(ctx, next) { await next(); };
+
+    class Stub extends Routes {
+      constructor() {
+        super('/api');
+        this.middleware1 = middleware1;
+        this.middleware2 = middleware2;
+      }
+
+      @mapping(Routes.GET, '/test')
+      @before('middleware1','middleware2')
+      pathHandler(ctx) {
+        ctx.status = 200;
+        ctx.body = {id: 3};
+      }
+    };
+    const router = new (require('koa-router'))();
+    const app = new Koa();
+
+    mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
+    Ravel.routes('test');
+    Ravel[coreSymbols.routesInit](router);
+
+    app.use(router.routes());
+    app.use(router.allowedMethods());
+
+    request(app.callback())
+    .get('/api/test')
+    .expect(200, {id: 3}, done);
   });
 });

--- a/test/core/test-routes.js
+++ b/test/core/test-routes.js
@@ -382,7 +382,7 @@ describe('Ravel', function() {
       const agent = request.agent(Ravel.server);
       async.series([
         function(next) {agent.get('/app/path').expect(501).end(next);},
-        function(next) {agent.get('/app/another').expect(404).end(next);}
+        function(next) {agent.post('/app/another').expect(404).end(next);}
       ], done);
     });
   });

--- a/test/core/test-routes.js
+++ b/test/core/test-routes.js
@@ -161,7 +161,7 @@ describe('Ravel', function() {
 
         @mapping(Routes.GET, '/path')
         @before('middleware1','middleware2')
-        *pathHandler(ctx) {
+        async pathHandler(ctx) {
           ctx.status = 200;
         }
       };
@@ -194,7 +194,7 @@ describe('Ravel', function() {
 
         @mapping(Routes.POST, '/path')
         @before('middleware1','middleware2')
-        *pathHandler(ctx) {
+        async pathHandler(ctx) {
           ctx.status = 200;
         }
       };
@@ -226,7 +226,7 @@ describe('Ravel', function() {
 
         @mapping(Routes.PUT, '/path')
         @before('middleware1','middleware2')
-        *pathHandler(ctx) {
+        async pathHandler(ctx) {
           ctx.status = 200;
         }
       };
@@ -259,7 +259,7 @@ describe('Ravel', function() {
 
         @mapping(Routes.DELETE, '/path')
         @before('middleware1','middleware2')
-        *pathHandler(ctx) {
+        async pathHandler(ctx) {
           ctx.status = 200;
         }
       };
@@ -293,7 +293,7 @@ describe('Ravel', function() {
 
         @mapping(Routes.GET, '/path')
         @before('middleware2')
-        *pathHandler(ctx) {
+        async pathHandler(ctx) {
           ctx.status(200);
         }
       };
@@ -331,12 +331,12 @@ describe('Ravel', function() {
         }
 
         @mapping(Routes.GET, '/path')
-        *pathHandler(ctx) {
+        async pathHandler(ctx) {
           ctx.status(200);
         }
 
         @before('middleware2') // this should just be ignored, since @mapping isn't present
-        *ignoredHandler(ctx) {
+        async ignoredHandler(ctx) {
           ctx.status(200);
         }
       };

--- a/test/db/decorators/test-transaction.js
+++ b/test/db/decorators/test-transaction.js
@@ -119,7 +119,7 @@ describe('Ravel', function() {
         handler() {}
       }
       mockery.registerMock(upath.join(app.cwd, 'stub'), Stub);
-      const transactionMiddleware = async function(ctx, next){ await next; };
+      const transactionMiddleware = async function(ctx, next){ await next(); };
       app.db = {
         middleware: sinon.stub().returns(transactionMiddleware)
       };
@@ -148,7 +148,7 @@ describe('Ravel', function() {
         handler() {}
       }
       mockery.registerMock(upath.join(app.cwd, 'stub2'), Stub2);
-      const transactionMiddleware = async function(ctx, next){ await next; };
+      const transactionMiddleware = async function(ctx, next){ await next(); };
       app.db = {
         middleware: sinon.stub().returns(transactionMiddleware)
       };

--- a/test/db/decorators/test-transaction.js
+++ b/test/db/decorators/test-transaction.js
@@ -128,9 +128,7 @@ describe('Ravel', function() {
       sinon.stub(router, 'get', function() {
         expect(app.db.middleware).to.have.been.calledWith('mysql', 'redis');
         expect(arguments[0]).to.equal('/app/path');
-        expect(arguments[1]).to.be.a.function;
-        expect(arguments[1].toString()).to.include('buildRestResponse');
-        expect(arguments[2]).to.equal(transactionMiddleware);
+        expect(Array.from(arguments).indexOf(transactionMiddleware)).to.be.greaterThan(0);
         done();
       });
       app[coreSymbols.routesInit](router);
@@ -157,9 +155,7 @@ describe('Ravel', function() {
       sinon.stub(router, 'get', function() {
         expect(app.db.middleware).to.have.been.calledWith('rethinkdb', 'mysql', 'redis');
         expect(arguments[0]).to.equal('/app/another/path');
-        expect(arguments[1]).to.be.a.function;
-        expect(arguments[1].toString()).to.include('buildRestResponse');
-        expect(arguments[2]).to.equal(transactionMiddleware);
+        expect(Array.from(arguments).indexOf(transactionMiddleware)).to.be.greaterThan(0);
         done();
       });
       app[coreSymbols.routesInit](router);

--- a/test/db/decorators/test-transaction.js
+++ b/test/db/decorators/test-transaction.js
@@ -119,7 +119,7 @@ describe('Ravel', function() {
         handler() {}
       }
       mockery.registerMock(upath.join(app.cwd, 'stub'), Stub);
-      const transactionMiddleware = function*(next){ yield next; };
+      const transactionMiddleware = async function(ctx, next){ await next; };
       app.db = {
         middleware: sinon.stub().returns(transactionMiddleware)
       };
@@ -148,7 +148,7 @@ describe('Ravel', function() {
         handler() {}
       }
       mockery.registerMock(upath.join(app.cwd, 'stub2'), Stub2);
-      const transactionMiddleware = function*(next){ yield next; };
+      const transactionMiddleware = async function(ctx, next){ await next; };
       app.db = {
         middleware: sinon.stub().returns(transactionMiddleware)
       };

--- a/test/db/test-database.js
+++ b/test/db/test-database.js
@@ -45,8 +45,8 @@ describe('db/database', function() {
   describe('#middleware()', function() {
     it('should populate context.transaction with an empty dictionary of database connection objects when no database providers are registered.', (done) => {
       app.use(database.middleware());
-      app.use(function*(){
-        expect(this).to.have.a.property('transaction').that.deep.equals({});
+      app.use(async function(ctx){
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({});
       });
 
       request(app.callback())
@@ -77,10 +77,10 @@ describe('db/database', function() {
       });
 
       app.use(database.middleware());
-      app.use(function*(){
+      app.use(async function(ctx){
         expect(mysqlGetTransactionSpy).to.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           mysql: mysqlConnection,
           postgres: postgresConnection
         });
@@ -114,10 +114,10 @@ describe('db/database', function() {
       });
 
       app.use(database.middleware('postgres'));
-      app.use(function*(){
+      app.use(async function(ctx){
         expect(mysqlGetTransactionSpy).to.not.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           postgres: postgresConnection
         });
       });
@@ -149,12 +149,12 @@ describe('db/database', function() {
       });
 
       const randomMessage = Math.random().toString();
-      app.use(function*(next) {
+      app.use(async function(ctx, next) {
         try {
-          yield next;
+          await next;
         } catch (err) {
-          this.status = 500;
-          this.body = randomMessage;
+          ctx.status = 500;
+          ctx.body = randomMessage;
         }
       });
       app.use(database.middleware());
@@ -184,10 +184,10 @@ describe('db/database', function() {
       });
 
       app.use(database.middleware());
-      app.use(function*(){
+      app.use(async function(ctx){
         expect(mysqlGetTransactionSpy).to.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           mysql: mysqlConnection,
           postgres: postgresConnection
         });
@@ -223,18 +223,18 @@ describe('db/database', function() {
         return Promise.resolve(null);
       });
 
-      app.use(function*(next) {
+      app.use(async function(ctx,next) {
         try {
-          yield next;
+          await next;
         } catch (err) {
           this.status = 300;
         }
       });
       app.use(database.middleware());
-      app.use(function*(){
+      app.use(async function(ctx){
         expect(mysqlGetTransactionSpy).to.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           mysql: mysqlConnection,
           postgres: postgresConnection
         });
@@ -271,18 +271,18 @@ describe('db/database', function() {
         return Promise.resolve();
       });
 
-      app.use(function*(next) {
+      app.use(async function(ctx, next) {
         try {
-          yield next;
+          await next;
         } catch (err) {
           this.status = 500;
         }
       });
       app.use(database.middleware());
-      app.use(function*(){
+      app.use(async function(ctx){
         expect(mysqlGetTransactionSpy).to.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           mysql: mysqlConnection,
           postgres: postgresConnection
         });
@@ -323,10 +323,10 @@ describe('db/database', function() {
         return Promise.resolve();
       });
 
-      database.scoped(function*() {
+      database.scoped(async function(ctx) {
         expect(mysqlGetTransactionSpy).to.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           mysql: mysqlConnection,
           postgres: postgresConnection
         });
@@ -355,10 +355,10 @@ describe('db/database', function() {
         return Promise.resolve();
       });
 
-      database.scoped('postgres', function*() {
+      database.scoped('postgres', async function(ctx) {
         expect(mysqlGetTransactionSpy).to.not.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           postgres: postgresConnection
         });
         done();
@@ -386,7 +386,7 @@ describe('db/database', function() {
         return Promise.resolve();
       });
 
-      const promise = database.scoped(function*() {
+      const promise = database.scoped(async function() {
       });
       expect(promise).to.eventually.be.rejectedWith(Error);
       expect(mysqlGetTransactionSpy).to.have.been.called;
@@ -415,10 +415,10 @@ describe('db/database', function() {
         return Promise.resolve();
       });
 
-      database.scoped(function*() {
+      database.scoped(async function(ctx) {
         expect(mysqlGetTransactionSpy).to.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           mysql: mysqlConnection,
           postgres: postgresConnection
         });
@@ -450,10 +450,10 @@ describe('db/database', function() {
         return Promise.resolve();
       });
 
-      database.scoped(function*() {
+      database.scoped(async function(ctx) {
         expect(mysqlGetTransactionSpy).to.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           mysql: mysqlConnection,
           postgres: postgresConnection
         });
@@ -490,10 +490,10 @@ describe('db/database', function() {
         return Promise.reject(null);
       });
 
-      database.scoped(function*() {
+      database.scoped(async function(ctx) {
         expect(mysqlGetTransactionSpy).to.have.been.called;
         expect(postgresGetTransactionSpy).to.have.been.called;
-        expect(this).to.have.a.property('transaction').that.deep.equals({
+        expect(ctx).to.have.a.property('transaction').that.deep.equals({
           mysql: mysqlConnection,
           postgres: postgresConnection
         });

--- a/test/db/test-database.js
+++ b/test/db/test-database.js
@@ -6,7 +6,7 @@ chai.use(require('chai-things'));
 chai.use(require('sinon-chai'));
 const sinon = require('sinon');
 const mockery = require('mockery');
-const koa = require('koa');
+const Koa = require('koa');
 const request = require('supertest');
 
 let Ravel, DatabaseProvider, app, database, mysqlProvider, postgresProvider;
@@ -20,7 +20,7 @@ describe('db/database', function() {
       warnOnUnregistered: false
     });
 
-    app = koa();
+    app = new Koa();
     Ravel = new (require('../../lib/ravel'))();
     DatabaseProvider = require('../../lib/ravel').DatabaseProvider;
     Ravel.log.setLevel('NONE');
@@ -151,7 +151,7 @@ describe('db/database', function() {
       const randomMessage = Math.random().toString();
       app.use(async function(ctx, next) {
         try {
-          await next;
+          await next();
         } catch (err) {
           ctx.status = 500;
           ctx.body = randomMessage;
@@ -225,9 +225,9 @@ describe('db/database', function() {
 
       app.use(async function(ctx,next) {
         try {
-          await next;
+          await next();
         } catch (err) {
-          this.status = 300;
+          ctx.status = 300;
         }
       });
       app.use(database.middleware());
@@ -273,9 +273,9 @@ describe('db/database', function() {
 
       app.use(async function(ctx, next) {
         try {
-          await next;
+          await next();
         } catch (err) {
-          this.status = 500;
+          ctx.status = 500;
         }
       });
       app.use(database.middleware());
@@ -286,8 +286,8 @@ describe('db/database', function() {
           mysql: mysqlConnection,
           postgres: postgresConnection
         });
-        this.status = 200;
-        this.body = {};
+        ctx.status = 200;
+        ctx.body = {};
       });
 
       request(app.callback())

--- a/test/ravel/test-ravel-lifecycle.js
+++ b/test/ravel/test-ravel-lifecycle.js
@@ -97,7 +97,7 @@ describe('Ravel lifeycle test', function() {
       constructor(users) {
         super('/api/user');
         this.users = users;
-        this.someMiddleware = async function(ctx, next) { await next; };
+        this.someMiddleware = async function(ctx, next) { await next(); };
       }
 
       @pre('someMiddleware')
@@ -156,27 +156,27 @@ describe('Ravel lifeycle test', function() {
       app.set('koa view engine', 'ejs');
       app.set('koa view directory', 'views');
 
-      const koaAppMock = require('koa')();
+      const koaAppMock = new (require('koa'))();
       const useSpy = sinon.spy(koaAppMock, 'use');
       mockery.registerMock('koa', function() { return koaAppMock; });
 
-      const session = async function(ctx, next) { await next; };
+      const session = async function(ctx, next) { await next(); };
       const sessionSpy = sinon.stub().returns(session);
       mockery.registerMock('koa-generic-session', sessionSpy);
 
-      const staticMiddleware = async function(ctx, next) { await next; };
+      const staticMiddleware = async function(ctx, next) { await next(); };
       const staticSpy = sinon.stub().returns(staticMiddleware);
       mockery.registerMock('koa-static', staticSpy);
 
-      const views = async function(ctx, next) { await next; };
+      const views = async function(ctx, next) { await next(); };
       const viewSpy = sinon.stub().returns(views);
       mockery.registerMock('koa-views', viewSpy);
 
-      const favicon = async function(ctx, next) { await next; };
+      const favicon = async function(ctx, next) { await next(); };
       const faviconSpy = sinon.stub().returns(favicon);
       mockery.registerMock('koa-favicon', faviconSpy);
 
-      const gzip = async function(ctx, next) { await next; };
+      const gzip = async function(ctx, next) { await next(); };
       const gzipSpy = sinon.stub().returns(gzip);
       mockery.registerMock('koa-compress', gzipSpy);
 

--- a/test/ravel/test-ravel-lifecycle.js
+++ b/test/ravel/test-ravel-lifecycle.js
@@ -97,7 +97,7 @@ describe('Ravel lifeycle test', function() {
       constructor(users) {
         super('/api/user');
         this.users = users;
-        this.someMiddleware = function*(next) { yield next; };
+        this.someMiddleware = async function(ctx, next) { await next; };
       }
 
       @pre('someMiddleware')
@@ -160,23 +160,23 @@ describe('Ravel lifeycle test', function() {
       const useSpy = sinon.spy(koaAppMock, 'use');
       mockery.registerMock('koa', function() { return koaAppMock; });
 
-      const session = function*(next) { yield next; };
+      const session = async function(ctx, next) { await next; };
       const sessionSpy = sinon.stub().returns(session);
       mockery.registerMock('koa-generic-session', sessionSpy);
 
-      const staticMiddleware = function*(next) { yield next; };
+      const staticMiddleware = async function(ctx, next) { await next; };
       const staticSpy = sinon.stub().returns(staticMiddleware);
       mockery.registerMock('koa-static', staticSpy);
 
-      const views = function*(next) { yield next; };
+      const views = async function(ctx, next) { await next; };
       const viewSpy = sinon.stub().returns(views);
       mockery.registerMock('koa-views', viewSpy);
 
-      const favicon = function*(next) { yield next; };
+      const favicon = async function(ctx, next) { await next; };
       const faviconSpy = sinon.stub().returns(favicon);
       mockery.registerMock('koa-favicon', faviconSpy);
 
-      const gzip = function*(next) { yield next; };
+      const gzip = async function(ctx, next) { await next; };
       const gzipSpy = sinon.stub().returns(gzip);
       mockery.registerMock('koa-compress', gzipSpy);
 

--- a/test/ravel/test-ravel-lifecycle.js
+++ b/test/ravel/test-ravel-lifecycle.js
@@ -101,12 +101,12 @@ describe('Ravel lifeycle test', function() {
       }
 
       @pre('someMiddleware')
-      *getAll(ctx) {
-        ctx.body = yield this.users.getAllUsers();
+      async getAll(ctx) {
+        ctx.body = await this.users.getAllUsers();
       }
 
-      *get(ctx) {
-        ctx.body = yield this.users.getUser(ctx.params.id);
+      async get(ctx) {
+        ctx.body = await this.users.getUser(ctx.params.id);
       }
     }
 
@@ -118,7 +118,7 @@ describe('Ravel lifeycle test', function() {
       }
 
       @mapping(Ravel.Routes.GET, '/app')
-      *handler(ctx) {
+      async handler(ctx) {
         ctx.body = '<!DOCTYPE html><html></html>';
         ctx.status = 200;
       }

--- a/test/ravel/test-ravel.js
+++ b/test/ravel/test-ravel.js
@@ -99,8 +99,8 @@ describe('Ravel end-to-end test', function() {
           }
 
           @pre('someMiddleware')
-          *getAll(ctx) {
-            const list = yield this.users.getAllUsers();
+          async getAll(ctx) {
+            const list = await this.users.getAllUsers();
             ctx.body = list;
           }
 
@@ -114,7 +114,7 @@ describe('Ravel end-to-end test', function() {
           }
 
           @pre('someMiddleware')
-          *post(ctx) {
+          async post() {
             throw new this.ApplicationError.DuplicateEntry();
           }
         }

--- a/test/ravel/test-ravel.js
+++ b/test/ravel/test-ravel.js
@@ -95,7 +95,7 @@ describe('Ravel end-to-end test', function() {
           constructor(users) {
             super('/api/user');
             this.users = users;
-            this.someMiddleware = function*(next) {yield next;};
+            this.someMiddleware = async function(ctx, next) {await next;};
           }
 
           @pre('someMiddleware')
@@ -129,11 +129,9 @@ describe('Ravel end-to-end test', function() {
           }
 
           @mapping(Ravel.Routes.GET, '/app')
-          appHandler(ctx) {
-            return function*() {
-              ctx.body = '<!DOCTYPE html><html></html>';
-              ctx.status = 200;
-            };
+          async appHandler(ctx) {
+            ctx.body = '<!DOCTYPE html><html></html>';
+            ctx.status = 200;
           }
 
           @mapping(Ravel.Routes.GET, '/login')

--- a/test/ravel/test-ravel.js
+++ b/test/ravel/test-ravel.js
@@ -95,7 +95,7 @@ describe('Ravel end-to-end test', function() {
           constructor(users) {
             super('/api/user');
             this.users = users;
-            this.someMiddleware = async function(ctx, next) {await next;};
+            this.someMiddleware = async function(ctx, next) {await next();};
           }
 
           @pre('someMiddleware')

--- a/test/util/test-rest.js
+++ b/test/util/test-rest.js
@@ -5,7 +5,7 @@ chai.use(require('chai-things'));
 chai.use(require('sinon-chai'));
 const mockery = require('mockery');
 const request = require('supertest');
-const koa = require('koa');
+const Koa = require('koa');
 const httpCodes = require('../../lib/util/http_codes');
 
 let Ravel, rest, app;
@@ -19,7 +19,7 @@ describe('util/rest', function() {
       warnOnUnregistered: false
     });
 
-    app = koa();
+    app = new Koa();
     Ravel = new (require('../../lib/ravel'))();
     Ravel.log.setLevel('NONE');
     Ravel.kvstore = {}; //mock Ravel.kvstore, since we're not actually starting Ravel.
@@ -39,8 +39,8 @@ describe('util/rest', function() {
   describe('#respond()', function() {
     it('should produce a response with HTTP 204 NO CONTENT if no body is supplied', function (done) {
       app.use(rest.respond());
-      app.use(function*() {
-        this.status = 200;
+      app.use(async function(ctx) {
+        ctx.status = 200;
       });
       request(app.callback())
       .get('/')
@@ -50,8 +50,8 @@ describe('util/rest', function() {
     it('should produce a response with HTTP 200 OK containing a string body if a json payload is supplied', function (done) {
       const result = {};
       app.use(rest.respond());
-      app.use(function*() {
-        this.body = result;
+      app.use(async function(ctx) {
+        ctx.body = result;
       });
       request(app.callback())
       .get('/')
@@ -64,8 +64,8 @@ describe('util/rest', function() {
         id:1
       };
       app.use(rest.respond());
-      app.use(function*() {
-        this.body = result;
+      app.use(async function(ctx) {
+        ctx.body = result;
       });
 
       request(app.callback())
@@ -78,8 +78,8 @@ describe('util/rest', function() {
 
     it('should allow the user to override the default success status code', function (done) {
       app.use(rest.respond());
-      app.use(function*() {
-        this.respondOptions = {
+      app.use(async function(ctx) {
+        ctx.respondOptions = {
           okCode: 201
         };
       });
@@ -99,9 +99,9 @@ describe('util/rest', function() {
       };
 
       app.use(rest.respond());
-      app.use(function*() {
-        this.body = result;
-        this.respondOptions = options;
+      app.use(async function(ctx) {
+        ctx.body = result;
+        ctx.respondOptions = options;
       });
 
       request(app.callback())
@@ -117,7 +117,7 @@ describe('util/rest', function() {
     it('should respond with HTTP 404 NOT FOUND when ApplicationError.NotFound is passed as err', (done) => {
       const message = 'a message';
       app.use(rest.errorHandler());
-      app.use(function*() {
+      app.use(async function() {
         throw new Ravel.ApplicationError.NotFound(message);
       });
       request(app.callback())
@@ -128,7 +128,7 @@ describe('util/rest', function() {
     it('should respond with HTTP 403 Forbidden when ApplicationError.Access is passed as err', (done) => {
       const message = 'a message';
       app.use(rest.errorHandler());
-      app.use(function*() {
+      app.use(async function() {
         throw new Ravel.ApplicationError.Access(message);
       });
       request(app.callback())
@@ -139,7 +139,7 @@ describe('util/rest', function() {
     it('should respond with HTTP 405 METHOD NOT ALLOWED when ApplicationError.NotAllowed is passed as err', (done) => {
       const message = 'a message';
       app.use(rest.errorHandler());
-      app.use(function*() {
+      app.use(async function() {
         throw new Ravel.ApplicationError.NotAllowed(message);
       });
       request(app.callback())
@@ -150,7 +150,7 @@ describe('util/rest', function() {
     it('should respond with HTTP 501 NOT IMPLEMENTED when ApplicationError.NotImplemented is passed as err', (done) => {
       const message = 'a message';
       app.use(rest.errorHandler());
-      app.use(function*() {
+      app.use(async function() {
         throw new Ravel.ApplicationError.NotImplemented(message);
       });
       request(app.callback())
@@ -161,7 +161,7 @@ describe('util/rest', function() {
     it('should respond with HTTP 409 CONFLICT when ApplicationError.DuplicateEntry is passed as err', (done) => {
       const message = 'a message';
       app.use(rest.errorHandler());
-      app.use(function*() {
+      app.use(async function() {
         throw new Ravel.ApplicationError.DuplicateEntry(message);
       });
       request(app.callback())
@@ -172,7 +172,7 @@ describe('util/rest', function() {
     it('should respond with HTTP 416 REQUESTED_RANGE_NOT_SATISFIABLE when ApplicationError.RangeOutOfBounds is passed as err', (done) => {
       const message = 'a message';
       app.use(rest.errorHandler());
-      app.use(function*() {
+      app.use(async function() {
         throw new Ravel.ApplicationError.RangeOutOfBounds(message);
       });
       request(app.callback())
@@ -183,7 +183,7 @@ describe('util/rest', function() {
     it('should respond with HTTP 400 BAD REQUEST when ApplicationError.IllegalValue is passed as err', (done) => {
       const message = 'a message';
       app.use(rest.errorHandler());
-      app.use(function*() {
+      app.use(async function() {
         throw new Ravel.ApplicationError.IllegalValue(message);
       });
       request(app.callback())
@@ -194,7 +194,7 @@ describe('util/rest', function() {
     it('should respond with HTTP 500 INTERNAL SERVER ERROR when an unknown Error type is passed as err', (done) => {
       const err = new Error('a message');
       app.use(rest.errorHandler());
-      app.use(function*() {
+      app.use(async function() {
         throw err;
       });
       request(app.callback())


### PR DESCRIPTION
Node v7+ has native async/await support, so it's time to convert Ravel to Koa 2 and drop generators.

This is a decently large overhaul, and API-breaking, so we'll be going to 0.18.0 when we release it.

Fixes #174 
Fixes #175 