### PR TITLE
Feature/180 route status code

### DIFF
--- a/lib/util/rest.js
+++ b/lib/util/rest.js
@@ -25,7 +25,11 @@ const buildRestResponse = function (ravelInstance, request, response, options) {
     if (response.body && request.method.toUpperCase() === 'POST') {
       options.okCode = httpCodes.CREATED;
     } else if (response.body) {
-      options.okCode = httpCodes.OK;
+      if (response.status > 201) {
+        options.okCode = httpCodes.OK;
+      }
+
+      options.okCode = response.status;
     } else if (response.status >= 200 && response.status < 300) {
       // set no-content on this route if there's no body and no status is already set
       options.okCode = httpCodes.NO_CONTENT;


### PR DESCRIPTION
Allow us to set HTTP status codes of 201 as well, since it is legal to have a body return a 'created' response.