### PR TITLE
Feature/221 - Async support for lifecycle decorators

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,8 +2,6 @@
 environment:
   matrix:
     - nodejs_version: "8"
-    - nodejs_version: "6"
-    - nodejs_version: "7"
 
 platform:
   - x64

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+  "retainLines": true,
+  "env": {
+    "test": {
+      "plugins": ["transform-decorators-legacy", "istanbul"]
+    }
+  },
+  "ignore": [
+    "resources/**"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ test-dist/*
 *.swp
 dist/*
 package-lock.json
+.nyc_output

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ before_install:
   - $CXX --version
   - npm install
 after_script:
-  - codeclimate-test-reporter < reports/lcov.info
+  - codeclimate-test-reporter < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
     - g++-4.8
 node_js:
   - "8"
-  - "7"
-  - "6"
 before_install:
   - $CXX --version
   - npm install

--- a/README.md
+++ b/README.md
@@ -294,13 +294,12 @@ A Ravel application is a root application file (such as `app.js`), coupled with 
 const Ravel = require('ravel');
 const app = new Ravel();
 
-// you'll register managed parameters, and connect Modules, Resources and Routes here
-
-app.init();
-
-// you'll set managed parameters here
-
-app.listen();
+(async function () {
+  // you'll register managed parameters, and connect Modules, Resources and Routes here
+  await app.init();
+  // you'll set managed parameters here
+  await app.listen();
+})();
 ```
 
 ### Managed Configuration System
@@ -325,8 +324,10 @@ app.registerParameter('my required parameter', true);
 // register a required parameter with a default value
 app.registerParameter('my third parameter', true, 'some value');
 
-app.init();
-app.listen();
+(async function () {
+  await app.init();
+  await app.listen();
+})();
 ```
 
 Many Ravel plugin libraries will automatically create parameters which you will have to supply values for. These parameters will be documented in their `README.md`.
@@ -344,14 +345,16 @@ const app = new Ravel();
 // register a new optional parameter
 app.registerParameter('my optional parameter');
 
-app.init();
+(async function () {
+  await app.init();
 
-// set a value
-app.set('my optional parameter', 'some value');
-// this won't work:
-app.set('an unknown parameter', 'some value');
+  // set a value
+  app.set('my optional parameter', 'some value');
+  // this won't work:
+  app.set('an unknown parameter', 'some value');
 
-app.listen();
+  await app.listen();
+})();
 ```
 
 #### app.get
@@ -367,16 +370,18 @@ const app = new Ravel();
 // register a new parameter
 app.registerParameter('my required parameter', true, 'default value');
 
-app.init();
+(async function () {
+  await app.init();
 
-// set a value
-app.set('my required parameter', 'some value');
-// get a value
-app.get('my required parameter') === 'some value';
-// this won't work:
-// app.get('an unknown parameter');
+  // set a value
+  app.set('my required parameter', 'some value');
+  // get a value
+  app.get('my required parameter') === 'some value';
+  // this won't work:
+  // app.get('an unknown parameter');
 
-app.listen();
+  await app.listen();
+})();
 ```
 
 #### Core parameters
@@ -773,7 +778,9 @@ const app = new require('ravel')();
 const MySQLProvider = require('ravel-mysql-provider');
 new MySQLProvider(app, 'mysql');
 // ... other providers and parameters
-app.init();
+(async function () {
+  await app.init();
+})();
 // ... the rest of your Ravel app
 ```
 
@@ -899,7 +906,9 @@ const app = new require('ravel')();
 const GitHubProvider = require('ravel-github-oauth2-provider');
 new GitHubProvider(app);
 // ... other providers and parameters
-app.init();
+(async function () {
+  await app.init();
+});
 // ... the rest of your Ravel app
 ```
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ A Ravel application is a root application file (such as `app.js`), coupled with 
 const Ravel = require('ravel');
 const app = new Ravel();
 
-(async function () {
+(async () => {
   // you'll register managed parameters, and connect Modules, Resources and Routes here
   await app.init();
   // you'll set managed parameters here
@@ -324,7 +324,7 @@ app.registerParameter('my required parameter', true);
 // register a required parameter with a default value
 app.registerParameter('my third parameter', true, 'some value');
 
-(async function () {
+(async () => {
   await app.init();
   await app.listen();
 })();
@@ -345,7 +345,7 @@ const app = new Ravel();
 // register a new optional parameter
 app.registerParameter('my optional parameter');
 
-(async function () {
+(async () => {
   await app.init();
 
   // set a value
@@ -370,7 +370,7 @@ const app = new Ravel();
 // register a new parameter
 app.registerParameter('my required parameter', true, 'default value');
 
-(async function () {
+(async () => {
   await app.init();
 
   // set a value
@@ -778,7 +778,7 @@ const app = new require('ravel')();
 const MySQLProvider = require('ravel-mysql-provider');
 new MySQLProvider(app, 'mysql');
 // ... other providers and parameters
-(async function () {
+(async () => {
   await app.init();
 })();
 // ... the rest of your Ravel app
@@ -906,7 +906,7 @@ const app = new require('ravel')();
 const GitHubProvider = require('ravel-github-oauth2-provider');
 new GitHubProvider(app);
 // ... other providers and parameters
-(async function () {
+(async () => {
   await app.init();
 });
 // ... the rest of your Ravel app

--- a/documentation.yml
+++ b/documentation.yml
@@ -55,13 +55,5 @@ toc:
   - name: Built-in Error Types
     description: |
       Built-in error types are automatically translated into standard HTTP response status codes when thrown.
-  - RavelError
-  - AccessError
-  - AuthenticationError
-  - DuplicateEntryError
-  - IllegalValueError
-  - NotAllowedError
-  - NotFoundError
-  - NotImplementedError
-  - RangeOutOfBoundsError
+  - ApplicationError
   - name: Other Stuff

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,6 +2,7 @@
 
 // koa-bodyparser doesn't transpile its dist :(
 if (process.version < 'v7.6.0') {
+  console.log('Transpiling decorators and async/await in node_modules');
   require('babel-register')({
     ignore: false,
     only: /koa-bodyparser|koa-static|koa-send|koa-session/,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,44 +12,19 @@ if (process.version < 'v7.6.0') {
 
 const gulp = require('gulp');
 const plugins = require('gulp-load-plugins')();
-// const isparta = require('isparta')
 const del = require('del');
 const exec = require('child_process').exec;
-
-const TESTS = [
-  'test-dist/test/core/decorators/test-*.js',
-  'test-dist/test/core/test-*.js',
-  'test-dist/test/db/test-*.js',
-  'test-dist/test/db/decorators/test-*.js',
-  'test-dist/test/util/test-*.js',
-  'test-dist/test/auth/test-*.js',
-  'test-dist/test/auth/decorators/test-*.js',
-  'test-dist/test/ravel/test-*.js',
-  'test-dist/test/**/test-*.js'
-];
 
 const babelConfig = {
   'retainLines': true
 };
-const MOCHA_OPTS = {
-  reporter: 'spec',
-  quiet: false,
-  colors: true,
-  timeout: 10000
-};
 
-if (process.version < 'v7.6.0' || process.execArgv.indexOf('test')) {
+if (process.execArgv.indexOf('test')) {
   console.log('Transpiling async/await...');
-  babelConfig.plugins = ['transform-decorators-legacy', 'transform-async-to-generator'];
+  babelConfig.plugins = ['transform-decorators-legacy', 'istanbul'];
 } else {
   console.log('Using native async/await...');
   babelConfig.plugins = ['transform-decorators-legacy'];
-}
-
-if (process.execArgv.indexOf('--inspect') >= 0 || process.execArgv.indexOf('--debug') >= 0) {
-  console.log('Using unlimited test timeouts...');
-  delete MOCHA_OPTS.timeout;
-  MOCHA_OPTS.enableTimeouts = false;
 }
 
 gulp.task('lint', function () {
@@ -77,86 +52,14 @@ gulp.task('docs', function (done) {
 
 gulp.task('clean', function () {
   return del([
-    'reports', 'docs', 'test-dist'
+    'coverage', 'docs', 'test-dist'
   ]);
-});
-
-gulp.task('cover-lib', ['transpile-lib'], function () {
-  return gulp.src(['./test-dist/lib/**/*.js'])
-    .pipe(plugins.istanbul({
-      //  instrumenter: isparta.Instrumenter,
-      includeUntested: true
-    }))
-    .pipe(plugins.istanbul.hookRequire());
-});
-
-gulp.task('copy-lib', ['clean', 'lint'], function () {
-  return gulp.src('lib/**/*.js')
-    .pipe(gulp.dest('test-dist/lib'));
 });
 
 gulp.task('dist', ['clean'], function () {
   return gulp.src('lib/**/*.js')
     .pipe(plugins.babel(babelConfig))
     .pipe(gulp.dest('dist'));
-});
-
-gulp.task('transpile-lib', ['clean', 'lint'], function () {
-  return gulp.src('lib/**/*.js')
-    .pipe(plugins.sourcemaps.init())
-    .pipe(plugins.babel(babelConfig))
-    .pipe(plugins.sourcemaps.write('.'))
-    .pipe(gulp.dest('test-dist/lib'));
-});
-
-gulp.task('transpile-tests', ['clean', 'lint'], function () {
-  return gulp.src('test/**/*.js')
-    .pipe(plugins.sourcemaps.init())
-    .pipe(plugins.babel(babelConfig))
-    .pipe(plugins.sourcemaps.write('.'))
-    .pipe(gulp.dest('test-dist/test'));
-});
-
-// necessary to locate issues in code, due to https://github.com/gotwarlost/istanbul/issues/274
-gulp.task('test-no-cov', ['copy-lib', 'transpile-tests'], function () {
-  const env = plugins.env.set({
-    LOG_LEVEL: 'critical',
-    NODE_ENV: 'testing'
-  });
-  return gulp.src(TESTS)
-    .pipe(env)
-    .pipe(plugins.mocha(MOCHA_OPTS))
-    .pipe(env.reset)
-    .once('error', function () {
-      process.exit(1);
-    })
-    .once('end', function () {
-      process.exit();
-    });
-});
-
-gulp.task('test', ['cover-lib', 'transpile-tests'], function () {
-  const env = plugins.env.set({
-    LOG_LEVEL: 'critical',
-    NODE_ENV: 'testing'
-  });
-  return gulp.src(TESTS)
-    .pipe(env)
-    .pipe(plugins.mocha(MOCHA_OPTS))
-    // Creating the reports after tests ran
-    .pipe(plugins.istanbul.writeReports({
-      dir: './reports',
-      reporters: ['lcov', 'json', 'text', 'text-summary', 'html']
-    }))
-    // Enforce a coverage of at least 100%
-    // .pipe(plugins.istanbul.enforceThresholds({ thresholds: { global: 100 } }))
-    .pipe(env.reset)
-    .once('error', function () {
-      process.exit(1);
-    })
-    .once('end', function () {
-      process.exit();
-    });
 });
 
 gulp.task('watch', ['lint', 'docs'], function () {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,15 +1,5 @@
 'use strict';
 
-// koa-bodyparser doesn't transpile its dist :(
-if (process.version < 'v7.6.0') {
-  console.log('Transpiling decorators and async/await in node_modules');
-  require('babel-register')({
-    ignore: false,
-    only: /koa-bodyparser|koa-static|koa-send|koa-session/,
-    plugins: ['transform-decorators-legacy', 'transform-async-to-generator']
-  });
-}
-
 const gulp = require('gulp');
 const plugins = require('gulp-load-plugins')();
 const del = require('del');
@@ -68,7 +58,7 @@ gulp.task('watch', ['lint', 'docs'], function () {
 });
 
 gulp.task('show-coverage', function () {
-  return gulp.src('./reports/index.html')
+  return gulp.src('./coverage/lcov-report/index.html')
     .pipe(plugins.open());
 });
 

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -324,7 +324,7 @@ Module.prototype[sInit] = function (ravelInstance) {
   // connect @interval
   const handlers = Metadata.getClassMeta(Object.getPrototypeOf(self), '@interval', Object.create(null));
   const intervals = [];
-  ravelInstance.once('post init', () => {
+  ravelInstance.once('post listen', () => {
     for (const f of Object.keys(handlers)) {
       intervals.push(setInterval(() => {
         self.log.trace(`Invoking @interval ${f}`);

--- a/lib/ravel.js
+++ b/lib/ravel.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const EventEmitter = require('events').EventEmitter;
+const AsyncEventEmitter = require('./util/event_emitter');
 const coreSymbols = require('./core/symbols');
 const Rest = require('./util/rest');
 
@@ -21,7 +21,7 @@ const sUncaughtRejections = Symbol('uncaughtRejections');
  * const Ravel = require('ravel');
  * const app = new Ravel();
  */
-class Ravel extends EventEmitter {
+class Ravel extends AsyncEventEmitter {
   /**
    * Creates a new Ravel app instance.
    *
@@ -150,9 +150,9 @@ class Ravel extends EventEmitter {
    * supplying parameters and registering modules, resources
    * routes and rooms.
    */
-  init () {
+  async init () {
     // application configuration is completed in constructor
-    this.emit('pre init');
+    await this.emit('pre init');
 
     // log uncaught errors to prevent ES6 promise error swallowing
     // https://www.hacksrus.net/blog/2015/08/a-solution-to-swallowed-exceptions-in-es6s-promises/
@@ -169,9 +169,9 @@ class Ravel extends EventEmitter {
     });
 
     // load parameters from .ravelrc.json file, if any
-    this.emit('pre load parameters');
+    await this.emit('pre load parameters');
     this[coreSymbols.loadParameters]();
-    this.emit('post load parameters');
+    await this.emit('post load parameters');
 
     this[sInitialized] = true;
 
@@ -241,14 +241,14 @@ class Ravel extends EventEmitter {
     require('./auth/passport_init.js')(this, router);
 
     // basic koa configuration is completed
-    this.emit('post config koa', app);
+    await this.emit('post config koa', app);
 
     // create registered modules using factories
     this[coreSymbols.moduleInit]();
 
-    this.emit('post module init');
+    await this.emit('post module init');
 
-    this.emit('pre routes init', app);
+    await this.emit('pre routes init', app);
 
     // create registered resources using factories
     this[coreSymbols.resourceInit](router);
@@ -264,18 +264,18 @@ class Ravel extends EventEmitter {
     this[sServer] = http.createServer(app.callback());
 
     // application configuration is completed
-    this.emit('post init');
+    await this.emit('post init');
   }
 
   /**
    * Starts the application. Must be called after `initialize()`.
    */
-  listen () {
-    return new Promise((resolve, reject) => {
-      if (!this[sInitialized]) {
-        reject(new this.ApplicationError.NotAllowed('Cannot call Ravel.listen() before Ravel.init()'));
-      } else {
-        this.emit('pre listen');
+  async listen () {
+    if (!this[sInitialized]) {
+      throw new this.ApplicationError.NotAllowed('Cannot call Ravel.listen() before Ravel.init()');
+    } else {
+      await this.emit('pre listen');
+      return new Promise((resolve, reject) => {
         // validate parameters
         this[coreSymbols.validateParameters]();
         // Start Koa server
@@ -285,35 +285,32 @@ class Ravel extends EventEmitter {
           this.emit('post listen');
           resolve();
         });
-      }
-    });
+      });
+    }
   }
 
   /**
    * Intializes and starts the application.
    */
-  start () {
-    this.init();
+  async start () {
+    await this.init();
     return this.listen();
   }
 
   /**
    * Stops the application. A no op if the server isn't running.
    */
-  close () {
-    return new Promise((resolve) => {
-      // console.log('closing')
-      this.emit('end');
-      if (!this[sServer] || !this[sListening]) {
-        resolve();
-      } else {
+  async close () {
+    await this.emit('end');
+    if (this[sServer] && this[sListening]) {
+      return new Promise((resolve) => {
         this[sServer].close(() => {
           this.log.info('Application server terminated.');
           this[sListening] = false;
           resolve();
         });
-      }
-    });
+      });
+    }
   }
 }
 

--- a/lib/util/application_error.js
+++ b/lib/util/application_error.js
@@ -9,7 +9,7 @@ const httpCodes = require('./http_codes');
  * things that can go wrong and, when used by a client, are
  * translated into HTTP status codes automatically in
  * `Resource` responses
- *
+ * @private
  */
 class RavelError extends Error {
   /**
@@ -17,6 +17,7 @@ class RavelError extends Error {
    *
    * @param {string} msg --AA message for this error..
    * @param  {number} code - An HTTP status code between 100 and 505.
+   * @private
    */
   constructor (msg, code) {
     super(msg);
@@ -34,6 +35,7 @@ class RavelError extends Error {
 /**
  * Access Error - Thrown when a user attempts to utilize functionality they are
  * not authenticated to access
+ * @private
  */
 class AccessError extends RavelError {
   /**
@@ -48,6 +50,7 @@ class AccessError extends RavelError {
 
 /**
  * Authentication Error - Most useful for creating authentication providers
+ * @private
  */
 class AuthenticationError extends RavelError {
   /**
@@ -63,6 +66,7 @@ class AuthenticationError extends RavelError {
 /**
  * Duplicate Entry Error - Thrown when an attempt is made to insert a record
  * into the database which violates a uniqueness constraint
+ * @private
  */
 class DuplicateEntryError extends RavelError {
   /**
@@ -77,6 +81,7 @@ class DuplicateEntryError extends RavelError {
 
 /**
  * Illegal Value Error - Thrown when the user supplies an illegal value
+ * @private
  */
 class IllegalValueError extends RavelError {
   /**
@@ -92,6 +97,7 @@ class IllegalValueError extends RavelError {
 /**
  * Not Allowed Error - Used to mark API functionality which is not permitted
  * to be accessed under the current application configuration
+ * @private
  */
 class NotAllowedError extends RavelError {
   /**
@@ -106,6 +112,7 @@ class NotAllowedError extends RavelError {
 
 /**
  * Not Found Error - Thrown when something is expected to exist, but is not found.
+ * @private
  */
 class NotFoundError extends RavelError {
   /**
@@ -121,6 +128,7 @@ class NotFoundError extends RavelError {
 /**
  * Not Implemented Error - Used to mark API functionality which has not yet
  * been implemented
+ * @private
  */
 class NotImplementedError extends RavelError {
   /**
@@ -136,6 +144,7 @@ class NotImplementedError extends RavelError {
 /**
  * Range Out Of Bounds Error - Used when a range of data is requested from a set
  * which is outside of the bounds of that set.
+ * @private
  */
 class RangeOutOfBoundsError extends RavelError {
   /**
@@ -149,18 +158,110 @@ class RangeOutOfBoundsError extends RavelError {
 }
 
 /**
+ * Built-in error types for Ravel. When thrown within (or up to) a `Routes` or
+ * `Resource` handler, the response to that request will automatically
+ * use the associated error status code (rather than a developer needing
+ * to catch their own errors and set status codes manually).
+ *
+ * You can create your own `Error` types associated with status codes by
+ * extending `Ravel.Error`.
+ */
+class ApplicationError {
+  /**
+   * Base error type. Associated with HTTP 500 Internal Server Error.
+   *
+   * @returns {RavelError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get General () { return RavelError; }
+
+  /**
+   * Access Error - Throw when a user attempts to utilize functionality they are
+   * not authenticated to access. Associated with HTTP 403 FORBIDDEN.
+   *
+   * @returns {AccessError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get Access () { return AccessError; }
+
+  /**
+   * Authentication Error - Throw when a user is not authenticated to perform
+   * some action. Associated with HTTP 401 UNAUTHORIZED.
+   *
+   * @returns {AuthenticationError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get Authentication () { return AuthenticationError; }
+
+  /**
+   * Duplicate Entry Error - Throw when an attempt is made to insert a record
+   * into the database which violates a uniqueness constraint. Associated
+   * with HTTP 409 CONFLICT.
+   *
+   * @returns {DuplicateEntryError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get DuplicateEntry () { return DuplicateEntryError; }
+
+  /**
+   * Illegal Value Error - Throw when the user supplies an illegal value.
+   * Associated with HTTP 400 BAD REQUEST.
+   *
+   * @returns {IllegalValueError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get IllegalValue () { return IllegalValueError; }
+
+  /**
+   * Not Allowed Error - Used to mark API functionality which is not permitted
+   * to be accessed under the current application configuration. Associated
+   * with HTTP 405 METHOD NOT ALLOWED.
+   *
+   * @returns {NotAllowedError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get NotAllowed () { return NotAllowedError; }
+
+  /**
+   * Not Found Error - Throw when something is expected to exist, but is not found.
+   * Associated with HTTP 404 NOT FOUND.
+   *
+   * @returns {NotFoundError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get NotFound () { return NotFoundError; }
+
+  /**
+   * Not Implemented Error - Throw to mark API functionality which has not yet
+   * been implemented. Associated with HTTP 501 NOT IMPLEMENTED.
+   *
+   * @returns {NotImplementedError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get NotImplemented () { return NotImplementedError; }
+
+  /**
+   * Range Out Of Bounds Error - Throw when a range of data is requested from a set
+   * which is outside of the bounds of that set. Associated with HTTP 416 REQUESTED RANGE NOT SATISFIABLE.
+   *
+   * @returns {RangeOutOfBoundsError} - The Error class.
+   * @static
+   * @readonly
+   */
+  static get RangeOutOfBounds () { return RangeOutOfBoundsError; }
+}
+
+/**
  * Export Ravel built-in errors as an Object.
  * @type Object
  * @private
  */
-module.exports = {
-  General: RavelError,
-  Access: AccessError,
-  Authentication: AuthenticationError,
-  DuplicateEntry: DuplicateEntryError,
-  IllegalValue: IllegalValueError,
-  NotAllowed: NotAllowedError,
-  NotFound: NotFoundError,
-  NotImplemented: NotImplementedError,
-  RangeOutOfBounds: RangeOutOfBoundsError
-};
+module.exports = ApplicationError;

--- a/lib/util/event_emitter.js
+++ b/lib/util/event_emitter.js
@@ -19,7 +19,7 @@ class Listener {
  * A more-or-less API-compatible implementation of EventEmitter which supports
  * async functions as listeners, where emit() returns a `Promise` which resolves
  * when each of the listeners have resolved (or rejects when one rejects).
- * Listeners are run in parallel.
+ * Listeners are run in parallel (no order is guaranteed).
  *
  * @private
  * @class AsyncEventEmitter
@@ -29,28 +29,25 @@ class AsyncEventEmitter {
     this[sEventMap] = new Map();
   }
 
+  /**
+   * AsyncEventEmitter does not support defaultMaxListeners.
+   */
   static get defaultMaxListeners () {
     throw new ApplicationError.NotImplemented('AsyncEventEmitter does not support defaultMaxListeners');
   }
 
+  /**
+   * AsyncEventEmitter does not support getMaxListeners.
+   */
   getMaxListeners () {
     throw new ApplicationError.NotImplemented('AsyncEventEmitter does not support getMaxListeners');
   }
 
+  /**
+   * AsyncEventEmitter does not support setMaxListeners.
+   */
   setMaxListeners () {
     throw new ApplicationError.NotImplemented('AsyncEventEmitter does not support setMaxListeners');
-  }
-
-  /**
-   * Alias for `on(eventName, listener)`.
-   *
-   * @param {any} eventName - The name of the event to attach to.
-   * @param {Function} listener - The listener callback (potentially an async function).
-   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
-   * @memberof AsyncEventEmitter
-   */
-  addListener (eventName, listener) {
-    return this.on(eventName, listener);
   }
 
   /**
@@ -69,6 +66,35 @@ class AsyncEventEmitter {
       this[sEventMap].set(eventName, []);
     }
     this[sEventMap].get(eventName).push(new Listener(listener, false));
+    return this;
+  }
+
+  /**
+   * Alias for `on(eventName, listener)`.
+   *
+   * @param {any} eventName - The name of the event to attach to.
+   * @param {Function} listener - The listener callback (potentially an async function).
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  addListener (eventName, listener) {
+    return this.on(eventName, listener);
+  }
+
+  /**
+   * Adds a one time listener function for the event named eventName. The next time eventName
+   * is triggered, this listener is removed and then invoked.
+   *
+   * @param {any} eventName - The name of the event to attach to.
+   * @param {Function} listener - The listener callback (potentially an async function).
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  once (eventName, listener) {
+    if (!this[sEventMap].has(eventName)) {
+      this[sEventMap].set(eventName, []);
+    }
+    this[sEventMap].get(eventName).push(new Listener(listener, true));
     return this;
   }
 
@@ -101,7 +127,7 @@ class AsyncEventEmitter {
    * @returns {Array[any]} - The events for which the emitter has registered listeners.
    */
   eventNames () {
-    return [...Map.keys()];
+    return [...this[sEventMap].keys()];
   }
 
   /**
@@ -112,60 +138,21 @@ class AsyncEventEmitter {
    * @memberof AsyncEventEmitter
    */
   listenerCount (eventName) {
-    return !Map.has(eventName) ? 0 : Map.get(eventName).length;
+    return !this[sEventMap].has(eventName) ? 0 : this[sEventMap].get(eventName).length;
   }
 
   /**
-   * Adds a one time listener function for the event named eventName. The next time eventName
-   * is triggered, this listener is removed and then invoked.
-   *
-   * @param {any} eventName - The name of the event to attach to.
-   * @param {Function} listener - The listener callback (potentially an async function).
-   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
-   * @memberof AsyncEventEmitter
+   * AsyncEventEmitter does not support prependListener.
    */
-  once (eventName, listener) {
-    if (!this[sEventMap].has(eventName)) {
-      this[sEventMap].set(eventName, []);
-    }
-    this[sEventMap].get(eventName).push(new Listener(listener, true));
-    return this;
+  prependListener () {
+    throw new ApplicationError.NotImplemented('AsyncEventEmitter does not support prependListener');
   }
 
   /**
-   * Adds the listener function to the beginning of the listeners array for the event named eventName.
-   * No checks are made to see if the listener has already been added. Multiple calls passing the
-   * same combination of eventName and listener will result in the listener being added,
-   * and called, multiple times.
-   *
-   * @param {any} eventName - The name of the event to attach to.
-   * @param {Function} listener - The listener callback (potentially an async function).
-   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
-   * @memberof AsyncEventEmitter
+   * AsyncEventEmitter does not support prependOnceListener..
    */
-  prependListener (eventName, listener) {
-    if (!this[sEventMap].has(eventName)) {
-      this[sEventMap].set(eventName, []);
-    }
-    this[sEventMap].get(eventName).unshift(new Listener(listener, false));
-    return this;
-  }
-
-  /**
-   * Adds a one time listener function for the event named eventName to the beginning of the
-   * listeners array. The next time eventName is triggered, this listener is removed, and then invoked.
-   *
-   * @param {any} eventName - The name of the event to attach to.
-   * @param {Function} listener - The listener callback (potentially an async function).
-   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
-   * @memberof AsyncEventEmitter
-   */
-  prependOnceListener (eventName, listener) {
-    if (!this[sEventMap].has(eventName)) {
-      this[sEventMap].set(eventName, []);
-    }
-    this[sEventMap].get(eventName).unshift(new Listener(listener, true));
-    return this;
+  prependOnceListener () {
+    throw new ApplicationError.NotImplemented('AsyncEventEmitter does not support prependOnceListener');
   }
 
   /**

--- a/lib/util/event_emitter.js
+++ b/lib/util/event_emitter.js
@@ -86,14 +86,11 @@ class AsyncEventEmitter {
     if (!this[sEventMap].has(eventName)) {
       return Promise.resolve();
     } else {
-      return Promise.all(
-        // map listeners to an array of promises
-        this[sEventMap].get(eventName).map(l => {
-          if (l.once) {
-            this.removeListener(eventName, l.listener);
-          }
-          return l.listener.apply(l.listener, args);
-        }));
+      const toExecute = this[sEventMap].get(eventName);
+      // remove onces immediately, before invoking
+      this[sEventMap].set(eventName, toExecute.filter(l => !l.once));
+      // invoke (mapping to promises)
+      return Promise.all(toExecute.map(l => l.listener.apply(l.listener, args)));
     }
   }
 

--- a/lib/util/event_emitter.js
+++ b/lib/util/event_emitter.js
@@ -1,0 +1,215 @@
+'use strict';
+
+const ApplicationError = require('./application_error');
+
+const sEventMap = Symbol('_eventMap');
+
+/**
+ * @private
+ * @class Listener
+ */
+class Listener {
+  constructor (listener, once = false) {
+    this.listener = listener;
+    this.once = once;
+  }
+}
+
+/**
+ * A more-or-less API-compatible implementation of EventEmitter which supports
+ * async functions as listeners, where emit() returns a `Promise` which resolves
+ * when each of the listeners have resolved (or rejects when one rejects).
+ * Listeners are run in parallel.
+ *
+ * @private
+ * @class AsyncEventEmitter
+ */
+class AsyncEventEmitter {
+  constructor () {
+    this[sEventMap] = new Map();
+  }
+
+  static get defaultMaxListeners () {
+    throw new ApplicationError.NotImplemented('AsyncEventEmitter does not support defaultMaxListeners');
+  }
+
+  getMaxListeners () {
+    throw new ApplicationError.NotImplemented('AsyncEventEmitter does not support getMaxListeners');
+  }
+
+  setMaxListeners () {
+    throw new ApplicationError.NotImplemented('AsyncEventEmitter does not support setMaxListeners');
+  }
+
+  /**
+   * Alias for `on(eventName, listener)`.
+   *
+   * @param {any} eventName - The name of the event to attach to.
+   * @param {Function} listener - The listener callback (potentially an async function).
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  addListener (eventName, listener) {
+    return this.on(eventName, listener);
+  }
+
+  /**
+   * Adds the listener function to the end of the listeners array for the event named eventName.
+   * No checks are made to see if the listener has already been added. Multiple calls passing
+   * the same combination of eventName and listener will result in the listener being added,
+   * and called, multiple times.
+   *
+   * @param {any} eventName - The name of the event to attach to.
+   * @param {Function} listener - The listener callback (potentially an async function).
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  on (eventName, listener) {
+    if (!this[sEventMap].has(eventName)) {
+      this[sEventMap].set(eventName, []);
+    }
+    this[sEventMap].get(eventName).push(new Listener(listener, false));
+    return this;
+  }
+
+  /**
+   * Calls each of the listeners registered for the event named eventName,
+   * in the order they were registered, passing the supplied arguments to each.
+   * Awaits on the successful result of ALL the listeners, returning a Promise.
+   *
+   * @param {any} eventName - The name of the event to emit.
+   * @param {...any} args - Arguments to pass to the listeners.
+   * @returns {Promise} - Resolves when all of the listeners resolve. Rejects otherwise.
+   * @memberof AsyncEventEmitter
+   */
+  emit (eventName, ...args) {
+    if (!this[sEventMap].has(eventName)) {
+      return Promise.resolve();
+    } else {
+      return Promise.all(
+        // map listeners to an array of promises
+        this[sEventMap].get(eventName).map(l => {
+          if (l.once) {
+            this.removeListener(eventName, l.listener);
+          }
+          return l.listener.apply(l.listener, args);
+        }));
+    }
+  }
+
+  /**
+   * Returns an array listing the events for which the emitter has registered listeners.
+   * The values in the array will be strings or Symbols.
+   *
+   * @returns {Array[any]} - The events for which the emitter has registered listeners.
+   */
+  eventNames () {
+    return [...Map.keys()];
+  }
+
+  /**
+   * Returns the number of listeners listening to the event named eventName.
+   *
+   * @param {any} eventName - The name of the event to emit.
+   * @returns {number} The number of listeners for the given event.
+   * @memberof AsyncEventEmitter
+   */
+  listenerCount (eventName) {
+    return !Map.has(eventName) ? 0 : Map.get(eventName).length;
+  }
+
+  /**
+   * Adds a one time listener function for the event named eventName. The next time eventName
+   * is triggered, this listener is removed and then invoked.
+   *
+   * @param {any} eventName - The name of the event to attach to.
+   * @param {Function} listener - The listener callback (potentially an async function).
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  once (eventName, listener) {
+    if (!this[sEventMap].has(eventName)) {
+      this[sEventMap].set(eventName, []);
+    }
+    this[sEventMap].get(eventName).push(new Listener(listener, true));
+    return this;
+  }
+
+  /**
+   * Adds the listener function to the beginning of the listeners array for the event named eventName.
+   * No checks are made to see if the listener has already been added. Multiple calls passing the
+   * same combination of eventName and listener will result in the listener being added,
+   * and called, multiple times.
+   *
+   * @param {any} eventName - The name of the event to attach to.
+   * @param {Function} listener - The listener callback (potentially an async function).
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  prependListener (eventName, listener) {
+    if (!this[sEventMap].has(eventName)) {
+      this[sEventMap].set(eventName, []);
+    }
+    this[sEventMap].get(eventName).unshift(new Listener(listener, false));
+    return this;
+  }
+
+  /**
+   * Adds a one time listener function for the event named eventName to the beginning of the
+   * listeners array. The next time eventName is triggered, this listener is removed, and then invoked.
+   *
+   * @param {any} eventName - The name of the event to attach to.
+   * @param {Function} listener - The listener callback (potentially an async function).
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  prependOnceListener (eventName, listener) {
+    if (!this[sEventMap].has(eventName)) {
+      this[sEventMap].set(eventName, []);
+    }
+    this[sEventMap].get(eventName).unshift(new Listener(listener, true));
+    return this;
+  }
+
+  /**
+   * Removes all listeners, or those of the specified eventName.
+   *
+   * Note that it is bad practice to remove listeners added elsewhere in the code,
+   * particularly when the EventEmitter instance was created by some other component
+   * or module (e.g. sockets or file streams).
+   *
+   * Returns a reference to the EventEmitter, so that calls can be chained.
+   *
+   * @param {any | undefined} eventName - The name of the event to remove all ilsteners for (optional).
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  removeAllListeners (eventName = null) {
+    if (eventName === null) {
+      this[sEventMap].clear();
+    } else if (this[sEventMap].has(eventName)) {
+      this[sEventMap].set(eventName, []);
+    }
+    return this;
+  }
+
+  /**
+   * Removes the specified listener from the listener array for the event named eventName.
+   *
+   * @param {any} eventName - The name of the event to remove the listener from.
+   * @param {Function} listener - The listener to remove.
+   * @returns {AsyncEventEmitter} - A Reference this AsyncEventEmitter so that calls can be chained.
+   * @memberof AsyncEventEmitter
+   */
+  removeListener (eventName, listener) {
+    if (this[sEventMap].has(eventName)) {
+      const idx = this[sEventMap].get(eventName).findIndex(e => e.listener === listener);
+      if (idx >= 0) {
+        this[sEventMap].get(eventName).splice(idx, 1);
+      }
+    }
+    return this;
+  }
+}
+
+module.exports = AsyncEventEmitter;

--- a/lib/util/event_emitter.js
+++ b/lib/util/event_emitter.js
@@ -65,7 +65,7 @@ class AsyncEventEmitter {
     if (!this[sEventMap].has(eventName)) {
       this[sEventMap].set(eventName, []);
     }
-    this[sEventMap].get(eventName).push(new Listener(listener, false));
+    this[sEventMap].get(eventName).push(new Listener(listener));
     return this;
   }
 

--- a/lib/util/response_cache.js
+++ b/lib/util/response_cache.js
@@ -135,7 +135,7 @@ class ResponseCacheMiddleware {
    * @returns {AsyncFunction} The caching middleware.
    * @private
    */
-  middleware (inOptions = {}) {
+  middleware (inOptions) {
     let options = Object.create(null);
     options = Object.assign(options, defaultOptions);
     options = Object.assign(options, inOptions);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "clean": "gulp clean",
     "docs": "gulp docs",
     "watch": "gulp watch",
-    "test": "cross-env NODE_ENV=test nyc mocha --recursive --timeout=10000 ./test",
+    "test": "cross-env NODE_ENV=test nyc mocha --recursive --exit --timeout=10000 ./test",
     "test-windows": "npm test",
     "show-coverage": "gulp show-coverage",
     "dist": "gulp dist",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Sean McIntyre <s.mcintyre@xverba.ca>",
   "description": "Ravel Rapid Application Development Framework",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "keywords": [
     "koa",
@@ -36,11 +36,9 @@
     "clean": "gulp clean",
     "docs": "gulp docs",
     "watch": "gulp watch",
-    "test": "node $(which gulp) --require source-map-support/register test",
-    "test-windows": "node node_modules/gulp/bin/gulp.js --require source-map-support/register test",
-    "test-no-cov": "node $(which gulp) --require source-map-support/register test-no-cov",
+    "test": "cross-env NODE_ENV=test nyc mocha --recursive --timeout=10000 ./test",
+    "test-windows": "npm test",
     "show-coverage": "gulp show-coverage",
-    "debug": "node --nolazy --debug-brk --inspect $(which gulp) --require source-map-support/register test-no-cov",
     "dist": "gulp dist",
     "prepare": "gulp dist"
   },
@@ -63,13 +61,13 @@
   },
   "devDependencies": {
     "async": "2.5.0",
+    "cross-env": "5.1.1",
     "chai": "4.0.2",
     "chai-as-promised": "7.1.1",
     "chai-things": "0.2.0",
     "documentation": "4.0.0-rc.1",
     "yamljs": "0.3.0",
-    "mocha": "3.4.2",
-    "mocha-lcov-reporter": "1.3.0",
+    "mocha": "4.0.1",
     "mockery": "2.1.0",
     "node-mocks-http": "1.6.4",
     "redis-mock": "0.20.0",
@@ -86,25 +84,44 @@
     "supertest": "3.0.0",
     "passport-local": "1.0.0",
     "koa-bodyparser": "4.2.0",
+    "nyc": "11.2.1",
     "codeclimate-test-reporter": "0.5.0",
     "del": "3.0.0",
     "gulp": "3.9.1",
     "gulp-env": "0.4.0",
-    "istanbul": "0.4.5",
-    "gulp-istanbul": "1.1.2",
     "gulp-eslint": "4.0.0",
     "gulp-load-plugins": "1.5.0",
-    "gulp-mocha": "3.0.1",
     "gulp-open": "2.0.0",
     "gulp-replace": "0.6.1",
-    "gulp-sourcemaps": "2.6.0",
-    "source-map-support": "0.4.15",
     "gulp-babel": "6.1.2",
     "babel-core": "6.25.0",
     "babel-eslint": "7.2.3",
     "babel-plugin-transform-async-to-generator": "6.24.1",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
+    "babel-plugin-istanbul": "4.1.5",
     "babel-register": "6.24.1"
   },
-  "false": {}
+  "nyc": {
+    "sourceMap": false,
+    "instrument": false,
+    "check-coverage": true,
+    "per-file": true,
+    "lines": 100,
+    "statements": 100,
+    "functions": 100,
+    "branches": 100,
+    "cache": true,
+    "all": true,
+    "require": "babel-register",
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "exclude": [
+      "resources/**"
+    ],
+    "include": [
+      "lib/**"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -94,12 +94,12 @@
     "gulp-open": "2.0.0",
     "gulp-replace": "0.6.1",
     "gulp-babel": "6.1.2",
-    "babel-core": "6.25.0",
+    "babel-core": "6.26.0",
     "babel-eslint": "7.2.3",
     "babel-plugin-transform-async-to-generator": "6.24.1",
     "babel-plugin-transform-decorators-legacy": "1.3.4",
     "babel-plugin-istanbul": "4.1.5",
-    "babel-register": "6.24.1"
+    "babel-register": "6.26.0"
   },
   "nyc": {
     "sourceMap": false,

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "watch": "gulp watch",
     "test": "cross-env NODE_ENV=test nyc mocha --recursive --exit --timeout=10000 ./test",
     "test-windows": "npm test",
+    "debug": "cross-env NODE_ENV=test mocha --no-timeouts --require babel-register --inspect-brk --recursive --exit ./test ",
     "show-coverage": "gulp show-coverage",
     "dist": "gulp dist",
     "prepare": "gulp dist"

--- a/resources/bad-ravelrc.json
+++ b/resources/bad-ravelrc.json
@@ -1,2 +1,0 @@
-{
-  "redis host": "localhost"

--- a/resources/syntax-error.js
+++ b/resources/syntax-error.js
@@ -1,1 +1,0 @@
-module.exports =

--- a/test/auth/test-authentication-provider.js
+++ b/test/auth/test-authentication-provider.js
@@ -61,7 +61,7 @@ describe('auth/authentication_provider', () => {
       expect(provider).to.have.property('credentialToProfile').that.is.a('function');
       expect(provider).to.have.property('log').that.is.an('object');
       expect(provider).to.have.property('ravelInstance').that.is.an('object');
-      expect(provider).to.have.property('ApplicationError').that.is.an('object');
+      expect(provider).to.have.property('ApplicationError').that.is.a('function');
       done();
     });
 

--- a/test/core/test-params.js
+++ b/test/core/test-params.js
@@ -237,7 +237,7 @@ describe('Ravel', () => {
       done();
     });
 
-    it('should load defaults if no configuration files are present', (done) => {
+    it('should load defaults if no configuration files are present', async () => {
       const oldParams = {
         'redis host': '0.0.0.0',
         'redis port': 6379,
@@ -252,10 +252,9 @@ describe('Ravel', () => {
         'log level': 'DEBUG'
       };
       Ravel.set('keygrip keys', ['123abc']);
-      Ravel.init();
+      await Ravel.init();
       // now load params from non-existent ravelrc file
       expect(Ravel.config).to.deep.equal(oldParams);
-      done();
     });
 
     it('should throw a SyntaxError if a .ravelrc file is found but is malformed', (done) => {

--- a/test/core/test-params.js
+++ b/test/core/test-params.js
@@ -5,6 +5,7 @@ const expect = chai.expect;
 chai.use(require('chai-things'));
 const mockery = require('mockery');
 const upath = require('upath');
+const sinon = require('sinon');
 
 let Ravel, conf, coreSymbols;
 
@@ -258,8 +259,14 @@ describe('Ravel', () => {
     });
 
     it('should throw a SyntaxError if a .ravelrc file is found but is malformed', (done) => {
-      mockery.registerSubstitute(upath.join(Ravel.cwd, '.ravelrc'), '../../../resources/bad-ravelrc.json');
+      const m = require('module');
+      const origLoad = m._load;
+      const stub = sinon.stub(m, '_load').callsFake((...args) => {
+        if (args[0] === upath.join(Ravel.cwd, '.ravelrc')) throw new SyntaxError();
+        return origLoad.apply(m, args);
+      });
       expect(() => { Ravel[coreSymbols.loadParameters](); }).to.throw(SyntaxError);
+      stub.restore();
       done();
     });
   });

--- a/test/core/test-reflect.js
+++ b/test/core/test-reflect.js
@@ -115,7 +115,7 @@ describe('Ravel', () => {
       done();
     });
 
-    it('should allow clients to retrieve metadata from Resources', (done) => {
+    it('should allow clients to retrieve metadata from Resources', async () => {
       const middleware1 = async function (ctx, next) { await next(); };
       const middleware2 = async function (ctx, next) { await next(); };
       const Resource = Ravel.Resource;
@@ -148,7 +148,7 @@ describe('Ravel', () => {
       app.set('koa public directory', 'public');
       app.set('keygrip keys', ['mysecret']);
       app.resource('./stub');
-      app.init();
+      await app.init();
 
       const meta = app.reflect('./stub').metadata;
 
@@ -180,7 +180,6 @@ describe('Ravel', () => {
           }
         }
       });
-      done();
     });
 
     it('should throw an ApplicationError.NotFound if the specified path is not a known Ravel component', (done) => {

--- a/test/core/test-resource.js
+++ b/test/core/test-resource.js
@@ -439,7 +439,7 @@ describe('Ravel', () => {
       ], done);
     });
 
-    it('should implement stub endpoints for unused HTTP verbs, all of which return a status httpCodes.NOT_IMPLEMENTED', (done) => {
+    it('should implement stub endpoints for unused HTTP verbs, all of which return a status httpCodes.NOT_IMPLEMENTED', async () => {
       mockery.registerMock('redis', require('redis-mock'));
       mockery.registerMock(upath.join(Ravel.cwd, 'test'), class extends Resource {
         constructor () {
@@ -453,18 +453,23 @@ describe('Ravel', () => {
       Ravel.set('koa public directory', 'public');
       Ravel.set('keygrip keys', ['mysecret']);
       Ravel.resource('test');
-      Ravel.init();
+      await Ravel.init();
       const agent = request.agent(Ravel.server);
 
-      async.series([
-        function (next) { agent.get('/api/test').expect(501).end(next); },
-        function (next) { agent.get('/api/test/1').expect(501).end(next); },
-        function (next) { agent.post('/api/test').expect(501).end(next); },
-        function (next) { agent.put('/api/test').expect(501).end(next); },
-        function (next) { agent.put('/api/test/2').expect(501).end(next); },
-        function (next) { agent.delete('/api/test').expect(501).end(next); },
-        function (next) { agent.delete('/api/test/50').expect(501).end(next); }
-      ], done);
+      return new Promise((resolve, reject) => {
+        async.series([
+          function (next) { agent.get('/api/test').expect(501).end(next); },
+          function (next) { agent.get('/api/test/1').expect(501).end(next); },
+          function (next) { agent.post('/api/test').expect(501).end(next); },
+          function (next) { agent.put('/api/test').expect(501).end(next); },
+          function (next) { agent.put('/api/test/2').expect(501).end(next); },
+          function (next) { agent.delete('/api/test').expect(501).end(next); },
+          function (next) { agent.delete('/api/test/50').expect(501).end(next); }
+        ], (err) => {
+          if (err) return reject(err);
+          resolve();
+        });
+      });
     });
 
     it('should facilitate the creation of routes which are not decorated with middleware', (done) => {

--- a/test/core/test-routes.js
+++ b/test/core/test-routes.js
@@ -375,7 +375,7 @@ describe('Ravel', () => {
         .expect(200, {}, done);
     });
 
-    it('should support the use of @mapping at the class level as well, to denote unsupported routes', (done) => {
+    it('should support the use of @mapping at the class level as well, to denote unsupported routes', async () => {
       @mapping(Routes.GET, '/path') // should respond with NOT_IMPLEMENTED
       @mapping(Routes.POST, '/another', 404) // should respond with 404
       class Stub extends Routes {
@@ -392,12 +392,17 @@ describe('Ravel', () => {
       Ravel.set('koa public directory', 'public');
       Ravel.set('keygrip keys', ['mysecret']);
       Ravel.routes('stub');
-      Ravel.init();
+      await Ravel.init();
       const agent = request.agent(Ravel.server);
-      async.series([
-        function (next) { agent.get('/app/path').expect(501).end(next); },
-        function (next) { agent.post('/app/another').expect(404).end(next); }
-      ], done);
+      return new Promise((resolve, reject) => {
+        async.series([
+          function (next) { agent.get('/app/path').expect(501).end(next); },
+          function (next) { agent.post('/app/another').expect(404).end(next); }
+        ], (err) => {
+          if (err) return reject(err);
+          resolve();
+        });
+      });
     });
   });
 

--- a/test/ravel/test-ravel-authentication.js
+++ b/test/ravel/test-ravel-authentication.js
@@ -49,7 +49,7 @@ describe('Authentication Integration Test', () => {
   });
 
   describe('Simulated Local Auth Provider', () => {
-    beforeEach((done) => {
+    beforeEach(async () => {
       const LocalStrategy = require('passport-local').Strategy;
       const bodyParser = require('koa-bodyparser');
 
@@ -154,9 +154,8 @@ describe('Authentication Integration Test', () => {
       ravelApp.module('authconfig', 'authconfig');
       mockery.registerMock(upath.join(ravelApp.cwd, 'routes'), TestRoutes);
       ravelApp.routes('routes');
-      ravelApp.init();
+      await ravelApp.init();
       agent = request.agent(ravelApp.server); //eslint-disable-line
-      done();
     });
 
     afterEach(() => {

--- a/test/ravel/test-ravel-caching.js
+++ b/test/ravel/test-ravel-caching.js
@@ -50,7 +50,7 @@ describe('Ravel end-to-end test', () => {
   });
 
   describe('basic application server consisting of a resource', () => {
-    before((done) => {
+    before(async () => {
       const Ravel = require('../../lib/ravel');
 
       // stub Resource (REST interface)
@@ -139,11 +139,10 @@ describe('Ravel end-to-end test', () => {
       app.resource('resources');
       mockery.registerMock(upath.join(app.cwd, 'routes'), TestRoutes);
       app.routes('routes');
-      app.init();
+      await app.init();
       app.kvstore.flushall();
 
       agent = request.agent(app.server);
-      done();
     });
 
     after((done) => {

--- a/test/ravel/test-ravel-caching.js
+++ b/test/ravel/test-ravel-caching.js
@@ -333,7 +333,7 @@ describe('Ravel end-to-end test', () => {
     });
 
     it('should gracefully handle caching errors coming from redis', (done) => {
-      setStub = sinon.stub(app.kvstore, 'set', function (key, value, cb) {
+      setStub = sinon.stub(app.kvstore, 'set').callsFake(function (key, value, cb) {
         return cb(new Error(), null);
       });
       agent

--- a/test/ravel/test-ravel.js
+++ b/test/ravel/test-ravel.js
@@ -36,7 +36,7 @@ describe('Ravel end-to-end test', () => {
 
   describe('#init()', () => {
     describe('uncaught ES6 Promise errors logging', () => {
-      it('should log unhandled erors within Promises', (done) => {
+      it('should log unhandled erors within Promises', async () => {
         mockery.registerMock('redis', redis);
         const Ravel = require('../../lib/ravel');
         app = new Ravel();
@@ -45,7 +45,7 @@ describe('Ravel end-to-end test', () => {
         app.set('redis port', 5432);
         app.set('keygrip keys', ['mysecret']);
         app.set('port', '9080');
-        app.init();
+        await app.init();
         for (let i = 0; i < 5; i++) {
           Promise.resolve('promised value').then(() => {
             throw new Error('error');
@@ -55,12 +55,11 @@ describe('Ravel end-to-end test', () => {
           });
         }
         // TODO actually test that logging occurred
-        done();
       });
     });
 
     describe('basic application server consisting of a module and a resource', () => {
-      before((done) => {
+      before(async () => {
         const Ravel = require('../../lib/ravel');
         const httpCodes = require('../../lib/util/http_codes');
         const ApplicationError = require('../../lib/util/application_error');
@@ -154,10 +153,9 @@ describe('Ravel end-to-end test', () => {
         app.resource('usersResource');
         mockery.registerMock(upath.join(app.cwd, 'routes'), TestRoutes);
         app.routes('routes');
-        app.init();
+        await app.init();
 
         agent = request.agent(app.server);
-        done();
       });
 
       after((done) => {

--- a/test/util/test-event-emitter.js
+++ b/test/util/test-event-emitter.js
@@ -1,0 +1,202 @@
+'use strict';
+
+const chai = require('chai');
+chai.use(require('chai-things'));
+chai.use(require('sinon-chai'));
+chai.use(require('chai-as-promised'));
+const expect = chai.expect;
+const sinon = require('sinon');
+const AsyncEventEmitter = require('../../lib/util/event_emitter');
+const ApplicationError = require('../../lib/util/application_error');
+
+let emitter;
+
+describe('Ravel', () => {
+  beforeEach(async () => {
+    emitter = new AsyncEventEmitter();
+  });
+
+  describe('AsyncEventEmitter', () => {
+    describe('defaultMaxListeners', () => {
+      it('should throw ApplicationError.NotImplemented', async () => {
+        expect(() => { AsyncEventEmitter.defaultMaxListeners; }).to.throw(ApplicationError.NotImplemented);
+      });
+    });
+
+    describe('#getMaxListeners', () => {
+      it('should throw ApplicationError.NotImplemented', async () => {
+        expect(() => { emitter.getMaxListeners(); }).to.throw(ApplicationError.NotImplemented);
+      });
+    });
+
+    describe('#setMaxListeners', () => {
+      it('should throw ApplicationError.NotImplemented', async () => {
+        expect(() => { emitter.setMaxListeners(); }).to.throw(ApplicationError.NotImplemented);
+      });
+    });
+
+    describe('#on', () => {
+      it('should register a listener for the given event, which fires when the event is triggered', async () => {
+        const stub = sinon.stub();
+        emitter.on('myevent', stub);
+        expect(emitter.eventNames()).to.include.something.that.equals('myevent');
+        await emitter.emit('myevent');
+        expect(stub).to.have.been.calledOnce;
+      });
+    });
+
+    describe('#addListener', () => {
+      it('should be an alias for emitter.on', async () => {
+        const spy = sinon.spy(emitter, 'on');
+        const listener = sinon.stub();
+        emitter.addListener('myevent', listener);
+        expect(spy).to.have.been.calledWith('myevent', listener);
+        expect(emitter.eventNames()).to.include.something.that.equals('myevent');
+        await emitter.emit('myevent');
+        expect(listener).to.have.been.calledOnce;
+      });
+    });
+
+    describe('#once', () => {
+      it('should register a one-time handler for an event', async () => {
+        const stub = sinon.stub();
+        emitter.once('myevent', stub);
+        expect(emitter.eventNames()).to.include.something.that.equals('myevent');
+        await emitter.emit('myevent');
+        await emitter.emit('myevent');
+        expect(stub).to.have.been.calledOnce;
+      });
+    });
+
+    describe('#emit', () => {
+      it('should trigger all listeners for an event, and return a Promise that resolves when they have all resolved.', async () => {
+        let finished = 0;
+        const stub1 = sinon.stub().returns(new Promise((resolve) => setTimeout(() => {
+          finished += 1;
+          resolve();
+        }, 100)));
+        const stub2 = sinon.stub().returns(new Promise((resolve) => setTimeout(() => {
+          finished += 1;
+          resolve();
+        }, 100)));
+        emitter.once('myevent', stub1);
+        emitter.once('myevent', stub2);
+        expect(emitter.eventNames()).to.include.something.that.equals('myevent');
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledOnce;
+        expect(stub2).to.have.been.calledOnce;
+        expect(finished).to.equal(2);
+      });
+
+      it('should be safe to call on events which do not exist', async () => {
+        expect(emitter.emit('someevent')).to.be.fulfilled;
+      });
+    });
+
+    describe('#eventNames', () => {
+      it('should return with a list of all the known event names for this emitter', async () => {
+        emitter.once('myevent', sinon.stub());
+        emitter.once('myevent2', sinon.stub());
+        expect(emitter.eventNames()).to.include.something.that.equals('myevent');
+        expect(emitter.eventNames()).to.include.something.that.equals('myevent2');
+      });
+    });
+
+    describe('#listenerCount', () => {
+      it('should return with the number of listeners for a known emitter', async () => {
+        emitter.once('myevent', sinon.stub());
+        emitter.once('myevent', sinon.stub());
+        expect(emitter.listenerCount('myevent')).to.equal(2);
+      });
+
+      it('should return with 0 for an unknown emitter', async () => {
+        expect(emitter.listenerCount('myevent')).to.equal(0);
+      });
+    });
+
+    describe('#prependListener', () => {
+      it('should throw ApplicationError.NotImplemented', async () => {
+        expect(() => { emitter.prependListener(); }).to.throw(ApplicationError.NotImplemented);
+      });
+    });
+
+    describe('#prependOnceListener', () => {
+      it('should throw ApplicationError.NotImplemented', async () => {
+        expect(() => { emitter.prependOnceListener(); }).to.throw(ApplicationError.NotImplemented);
+      });
+    });
+
+    describe('#removeAllListeners', () => {
+      it('should deregister all listeners when no event name is specified', async () => {
+        emitter.on('one', sinon.stub());
+        emitter.on('one', sinon.stub());
+        emitter.on('two', sinon.stub());
+        expect(emitter.eventNames()).to.contain.something.that.equals('one');
+        expect(emitter.eventNames()).to.contain.something.that.equals('two');
+        emitter.removeAllListeners();
+        expect(emitter.eventNames()).to.be.empty;
+      });
+
+      it('should deregister all listeners for a specific event when that event is specified', async () => {
+        emitter.on('one', sinon.stub());
+        emitter.on('one', sinon.stub());
+        emitter.on('two', sinon.stub());
+        expect(emitter.eventNames()).to.contain.something.that.equals('one');
+        expect(emitter.eventNames()).to.contain.something.that.equals('two');
+        emitter.removeAllListeners('two');
+        expect(emitter.eventNames()).to.contain.something.that.equals('one');
+      });
+
+      it('should be safe to call on events which do not exist', async () => {
+        const stub1 = sinon.stub();
+        emitter.on('myevent', stub1);
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledOnce;
+        emitter.removeAllListeners('anotherevent');
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledTwice;
+      });
+    });
+
+    describe('#removeListener', () => {
+      it('should facilitate the removal of specific listeners from an event', async () => {
+        const stub1 = sinon.stub();
+        const stub2 = sinon.stub();
+        emitter.on('myevent', stub1);
+        emitter.on('myevent', stub2);
+        emitter.on('anotherevent', stub1);
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledOnce;
+        expect(stub2).to.have.been.calledOnce;
+        await emitter.emit('anotherevent');
+        expect(stub1).to.have.been.calledTwice;
+        emitter.removeListener('myevent', stub1);
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledTwice;
+        expect(stub2).to.have.been.calledTwice;
+        await emitter.emit('anotherevent');
+        expect(stub1).to.have.been.calledThrice;
+      });
+
+      it('should be safe to call on events which do not exist', async () => {
+        const stub1 = sinon.stub();
+        emitter.on('myevent', stub1);
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledOnce;
+        emitter.removeListener('anotherevent', stub1);
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledTwice;
+      });
+
+      it('should be safe to call on listeners which do not exist', async () => {
+        const stub1 = sinon.stub();
+        emitter.on('myevent', stub1);
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledOnce;
+        emitter.removeListener('myevent', sinon.stub());
+        await emitter.emit('myevent');
+        expect(stub1).to.have.been.calledTwice;
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #221

This is a big, but necessary, one. This allows the client to `await` on `app.init()` or `app.listen()` and have a guarantee that all the lifecycle listeners in their `Modules` execute at the appropriate time. The guts of the change is an almost API-compatible implementation of `EventEmitter` where `emit()` returns a `Promise`.

In this course of this, I also had to upgrade our testing framework to use the latest `istanbuljs`/`nyc` stuff to get proper coverage measurements of the code, since legacy `istanbul` does not support `async`/`await`.

I've also dropped support for Node 6 and 7 to simplify things - I think it's time.