### PR TITLE
Feature/208 - @middleware decorator

### DIFF
--- a/lib/core/decorators/middleware.js
+++ b/lib/core/decorators/middleware.js
@@ -1,0 +1,41 @@
+const Metadata = require('../../util/meta');
+
+/**
+ * Method-level decorator for `Module` methods, so that
+ * they are registered as middleware which can be injected
+ * automatically by `@before`.
+ * Made available through the Module class.
+ * See [`Module`](#module) for more information.
+ *
+ * @param {string} name - The injection name this middlware will be made available under.
+ * @example
+ * const Module = require('ravel').Module;
+ * const middleware = Module.middleware;
+ * class MyModule extends Module {
+ *   // &#64;middleware('my-middleware')
+ *   async doSomething (ctx, next) {
+ *     //...
+ *   }
+ * }
+ * //...
+ * const Resource = require('ravel').Resource;
+ * const before = Resource.before;
+ * class MyResource extends Resource {
+ *   // &#64;before('my-middleware')
+ *   async getAll () {
+ *     //...
+ *   }
+ * }
+ *
+ * @private
+ */
+function middleware (name) {
+  return function (target, key, descriptor) {
+    Metadata.putClassMeta(target, '@middleware', name, descriptor.value);
+  };
+}
+
+/**
+ * @private
+ */
+module.exports = middleware;

--- a/lib/core/injector.js
+++ b/lib/core/injector.js
@@ -49,6 +49,9 @@ class Injector {
     } else if (this[sRavelInstance][coreSymbols.moduleFactories][moduleName] !== undefined) {
       // if the requested module is a registered module
       return this[sRavelInstance][coreSymbols.modules][moduleName];
+    } else if (this[sRavelInstance][coreSymbols.middleware][moduleName] !== undefined) {
+      // if the requested module is a registered middleware function
+      return this[sRavelInstance][coreSymbols.middleware][moduleName];
     } else {
       try {
         const requiredModule = this[sRequireModule].require(moduleName);

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -373,6 +373,7 @@ Module.prototype[sInit] = function (ravelInstance) {
         throw new this.ApplicationError.DuplicateEntry(
           `Unable to register @middleware with name ${m}, which conflicts with an existing Module name`);
       } else {
+        this.log.info(`Registering middleware with name ${m}`);
         ravelInstance[symbols.middleware][m] = middleware[m].bind(self);
       }
     }
@@ -515,6 +516,7 @@ module.exports = function (Ravel) {
         instantiationOrder[depth] = [];
       }
       instantiationOrder[depth].push(this[symbols.moduleFactories][moduleName]);
+      this.log.info(`Registering module with name ${moduleName}`);
     }
 
     // instantiate in depth order

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -4,6 +4,7 @@ const upath = require('upath');
 const symbols = require('./symbols');
 const Metadata = require('../util/meta');
 const lifecycle = require('./decorators/lifecycle');
+const middleware = require('./decorators/middleware');
 
 const sInit = Symbol.for('_init');
 
@@ -177,6 +178,34 @@ class Module {
   static get preclose () { return lifecycle.preclose; }
 
   /**
+   * Methods decorated with `@middleware` are registered
+   * they are registered as middleware which can be injected
+   * automatically by `@before` within `Resource`s and `Routes`.
+   *
+   * @example
+   * const Module = require('ravel').Module;
+   * const middleware = Module.middleware;
+   * class MyModule extends Module {
+   *   // &#64;middleware('my-middleware')
+   *   async doSomething (ctx, next) {
+   *     //...
+   *   }
+   * }
+   * //...
+   * const Resource = require('ravel').Resource;
+   * const before = Resource.before;
+   * class MyResource extends Resource {
+   *   // &#64;before('my-middleware')
+   *   async getAll () {
+   *     //...
+   *   }
+   * }
+   *
+   * @private
+   */
+  static get middleware () { return middleware; }
+
+  /**
    * A reference to the ravel instance with which this Module is registered.
    *
    * @type Ravel
@@ -334,6 +363,19 @@ Module.prototype[sInit] = function (ravelInstance) {
   });
   ravelInstance.once('end', () => {
     intervals.forEach((i) => clearInterval(i));
+  });
+
+  // register middleware
+  const middleware = Metadata.getClassMeta(Object.getPrototypeOf(self), '@middleware', Object.create(null));
+  ravelInstance.once('post module init', () => {
+    for (const m of Object.keys(middleware)) {
+      if (ravelInstance[symbols.moduleFactories][m]) {
+        throw new this.ApplicationError.DuplicateEntry(
+          `Unable to register @middleware with name ${m}, which conflicts with an existing Module name`);
+      } else {
+        ravelInstance[symbols.middleware][m] = middleware[m].bind(self);
+      }
+    }
   });
 };
 

--- a/lib/core/symbols.js
+++ b/lib/core/symbols.js
@@ -10,6 +10,7 @@ module.exports = {
   params: Symbol.for('_params'),
   knownParameters: Symbol.for('_knownParamters'),
   modules: Symbol.for('_modules'),
+  middleware: Symbol.for('_middleware'),
   moduleFactories: Symbol.for('_moduleFactories'),
   resourceFactories: Symbol.for('_resourceFactories'),
   routesFactories: Symbol.for('_routesFactories'),

--- a/lib/ravel.js
+++ b/lib/ravel.js
@@ -38,6 +38,8 @@ class Ravel extends AsyncEventEmitter {
 
     // how we store modules for dependency injection
     this[coreSymbols.modules] = Object.create(null);
+    // how we store middleware for dependency injection
+    this[coreSymbols.middleware] = Object.create(null);
 
     // current working directory of the app using the
     // ravel library, so that client modules can be

--- a/test/core/decorators/test-middleware.js
+++ b/test/core/decorators/test-middleware.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const mockery = require('mockery');
+const sinon = require('sinon');
+chai.use(require('sinon-chai'));
+const upath = require('upath');
+const Metadata = require('../../../lib/util/meta');
+
+let app, middleware, coreSymbols, Module, Routes;
+
+describe('Ravel', () => {
+  describe('@cache()', () => {
+    beforeEach((done) => {
+      // enable mockery
+      mockery.enable({
+        useCleanCache: true,
+        warnOnReplace: false,
+        warnOnUnregistered: false
+      });
+
+      const Ravel = require('../../../lib/ravel');
+      Module = Ravel.Module;
+      Routes = Ravel.Routes;
+      app = new Ravel();
+      app.log.setLevel('NONE');
+      middleware = Module.middleware;
+      coreSymbols = require('../../../lib/core/symbols');
+      done();
+    });
+
+    afterEach((done) => {
+      app = undefined;
+      middleware = undefined;
+      coreSymbols = undefined;
+      mockery.deregisterAll();
+      mockery.disable();
+      done();
+    });
+
+    it('should register a Module method as injectable middleware', (done) => {
+      class Stub1 {
+        @middleware('some-middleware')
+        async someMiddleware () {}
+      }
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@middleware', 'some-middleware')).to.be.a('function');
+      done();
+    });
+  });
+});

--- a/test/core/test-routes.js
+++ b/test/core/test-routes.js
@@ -404,38 +404,38 @@ describe('Ravel', () => {
         });
       });
     });
-  });
 
-  it('should support non-async handlers as well', (done) => {
-    const middleware1 = async function (ctx, next) { await next(); };
-    const middleware2 = async function (ctx, next) { await next(); };
+    it('should support non-async handlers as well', (done) => {
+      const middleware1 = async function (ctx, next) { await next(); };
+      const middleware2 = async function (ctx, next) { await next(); };
 
-    class Stub extends Routes {
-      constructor () {
-        super('/api');
-        this.middleware1 = middleware1;
-        this.middleware2 = middleware2;
+      class Stub extends Routes {
+        constructor () {
+          super('/api');
+          this.middleware1 = middleware1;
+          this.middleware2 = middleware2;
+        }
+
+        @mapping(Routes.GET, '/test')
+        @before('middleware1', 'middleware2')
+        pathHandler (ctx) {
+          ctx.status = 200;
+          ctx.body = {id: 3};
+        }
       }
+      const router = new (require('koa-router'))();
+      const app = new Koa();
 
-      @mapping(Routes.GET, '/test')
-      @before('middleware1', 'middleware2')
-      pathHandler (ctx) {
-        ctx.status = 200;
-        ctx.body = {id: 3};
-      }
-    }
-    const router = new (require('koa-router'))();
-    const app = new Koa();
+      mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
+      Ravel.routes('test');
+      Ravel[coreSymbols.routesInit](router);
 
-    mockery.registerMock(upath.join(Ravel.cwd, 'test'), Stub);
-    Ravel.routes('test');
-    Ravel[coreSymbols.routesInit](router);
+      app.use(router.routes());
+      app.use(router.allowedMethods());
 
-    app.use(router.routes());
-    app.use(router.allowedMethods());
-
-    request(app.callback())
-      .get('/api/test')
-      .expect(200, {id: 3}, done);
+      request(app.callback())
+        .get('/api/test')
+        .expect(200, {id: 3}, done);
+    });
   });
 });

--- a/test/ravel/test-ravel-middleware.js
+++ b/test/ravel/test-ravel-middleware.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const mockery = require('mockery');
+const redis = require('redis-mock');
+const request = require('supertest');
+const upath = require('upath');
+const sinon = require('sinon');
+chai.use(require('sinon-chai'));
+
+let app, agent;
+
+describe('Ravel end-to-end middleware test', () => {
+  before((done) => {
+    process.removeAllListeners('unhandledRejection');
+    // enable mockery
+    mockery.enable({
+      useCleanCache: true,
+      warnOnReplace: false,
+      warnOnUnregistered: false
+    });
+    done();
+  });
+
+  after((done) => {
+    process.removeAllListeners('unhandledRejection');
+    mockery.deregisterAll();
+    mockery.disable();
+    done();
+  });
+
+  describe('basic application server consisting of routes', () => {
+    before(async () => {
+      const Ravel = require('../../lib/ravel');
+      // stub Routes (miscellaneous routes, such as templated HTML content)
+      const middleware = Ravel.Module.middleware;
+      const pre = Ravel.Routes.before;
+      const mapping = Ravel.Routes.mapping;
+
+      class TestModule extends Ravel.Module {
+        @middleware('some-middleware')
+        async someMiddleware(ctx, next) {
+          ctx.body = 'Hello';
+          await next();
+        }
+      }
+
+      class TestRoutes extends Ravel.Routes {
+        constructor () {
+          super('/api/routes');
+        }
+
+        @pre('some-middleware')
+        @mapping(Ravel.Routes.GET, '/')
+        getHandler (ctx) {
+          ctx.body += ' World!';
+        }
+      }
+
+      mockery.registerMock('redis', redis);
+      app = new Ravel();
+      app.set('log level', app.log.NONE);
+      app.set('redis host', 'localhost');
+      app.set('redis port', 5432);
+      app.set('port', '9080');
+      app.set('koa public directory', 'public');
+      app.set('keygrip keys', ['mysecret']);
+
+      mockery.registerMock(upath.join(app.cwd, 'module'), TestModule);
+      app.module('module', 'module');
+      mockery.registerMock(upath.join(app.cwd, 'routes'), TestRoutes);
+      app.routes('routes');
+      await app.init();
+      app.kvstore.flushall();
+
+      agent = request.agent(app.server);
+    });
+
+    after(async () => {
+      app = undefined;
+    });
+
+    it('@middleware should make a module method available as middleware for use with @before', (done) => {
+      agent
+        .get('/api/routes')
+        .expect(200, 'Hello World!')
+        .end(done);
+    });
+  });
+});

--- a/test/ravel/test-ravel.js
+++ b/test/ravel/test-ravel.js
@@ -66,6 +66,7 @@ describe('Ravel end-to-end test', () => {
         const inject = Ravel.inject;
 
         // stub Module (business logic container)
+        const middleware = Ravel.Module.middleware;
         class Users extends Ravel.Module {
           getAllUsers () {
             return Promise.resolve(u);
@@ -78,6 +79,9 @@ describe('Ravel end-to-end test', () => {
               return Promise.reject(new this.ApplicationError.NotFound('User id=' + userId + ' does not exist!'));
             }
           }
+
+          @middleware('some-middleware')
+          async someMiddleware (ctx, next) { await next(); }
         }
 
         // stub Resource (REST interface)
@@ -88,16 +92,15 @@ describe('Ravel end-to-end test', () => {
           constructor (users) {
             super('/api/user');
             this.users = users;
-            this.someMiddleware = async function (ctx, next) { await next(); };
           }
 
-          @pre('someMiddleware')
+          @pre('some-middleware')
           async getAll (ctx) {
             const list = await this.users.getAllUsers();
             ctx.body = list;
           }
 
-          @pre('someMiddleware')
+          @pre('some-middleware')
           get (ctx) {
             // return promise and don't catch possible error so that Ravel can catch it
             return this.users.getUser(ctx.params.id)
@@ -106,7 +109,7 @@ describe('Ravel end-to-end test', () => {
               });
           }
 
-          @pre('someMiddleware')
+          @pre('some-middleware')
           async post () {
             throw new this.ApplicationError.DuplicateEntry();
           }


### PR DESCRIPTION
Make individual `Module` methods injectable as middleware via `@before` in `Routes` and `Resource`s. This will help reduce cluttering in `Routes` and `Resource` constructors by manual middleware `@inject`ion and assignments, and generally make it easier to understand how to create custom middleware in Ravel.

Example:

```js
const Module = require('ravel').Module;
const middleware = Module.middleware;
class MyModule extends Module {
  // @middleware('my-middleware')
  async doSomething (ctx, next) {
    //...
  }
}
//...
const Resource = require('ravel').Resource;
const before = Resource.before;
class MyResource extends Resource {
  // @before('my-middleware')
  async getAll () {
    //...
  }
}
```

Fixes #208 