### PR TITLE
Fix for #234 - local kvstore issue

### DIFF
--- a/lib/util/kvstore.js
+++ b/lib/util/kvstore.js
@@ -56,7 +56,7 @@ function createClient (ravelInstance, restrict = true) {
       ? 'Using in-memory key-value store. Please do not scale this app horizontally.'
       : `Using redis at ${ravelInstance.get('redis host')}:${ravelInstance.get('redis port')}`);
   });
-  const client = localRedis ? require('redis-mock') : redis.createClient(
+  const client = localRedis ? require('redis-mock').createClient() : redis.createClient(
     ravelInstance.get('redis port'),
     ravelInstance.get('redis host'),
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravel",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "author": "Sean McIntyre <s.mcintyre@xverba.ca>",
   "description": "Ravel Rapid Application Development Framework",
   "engines": {
@@ -24,6 +24,10 @@
     {
       "name": "Sean McIntyre",
       "email": "s.mcintyre@xverba.ca"
+    },
+    {
+      "name": "Michael Laccetti",
+      "email": "michael@laccetti.com"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
When using `redis-mock`, we still have to call `createClient` to get the party started.

Fixes #234.