### PR TITLE
Getting rid of koa-views

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,8 +396,6 @@ app.set('session max age', null); // session maxAge (default never expires)
 app.set('app route', '/'); // if you have a UI, this is the path users will be sent to when they are logged in
 app.set('login route', '/login'); // if users aren't logged in and you redirect them, this is where they'll be sent
 app.set('koa public directory', undefined); // if you want to statically serve a directory
-app.set('koa view directory', undefined); // for templated views (EJS, Pug, etc.)
-app.set('koa view engine', undefined); // for templated views (EJS, Pug, etc.)
 app.set('koa favicon path', undefined); // favicon middleware configuration
 ```
 

--- a/lib/ravel.js
+++ b/lib/ravel.js
@@ -79,8 +79,6 @@ class Ravel extends AsyncEventEmitter {
     // Node/koa parameters
     this.registerParameter('port', true, 8080);
     this.registerParameter('koa public directory');
-    this.registerParameter('koa view directory');
-    this.registerParameter('koa view engine');
     this.registerParameter('koa favicon path');
     this.registerParameter('keygrip keys', true);
     // session parameters
@@ -228,16 +226,6 @@ class Ravel extends AsyncEventEmitter {
                          The expiration is reset to the original maxAge, resetting the expiration
                          countdown. default is false */
     }, app));
-
-    // configure view engine
-    if (this.get('koa view engine') && this.get('koa view directory')) {
-      const views = require('koa-views');
-      app.use(views(upath.join(this.cwd, this.get('koa view directory')), {
-        map: {
-          html: this.get('koa view engine')
-        }
-      }));
-    }
 
     // favicon
     if (this.get('koa favicon path')) {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "koa-router": "7.4.0",
     "koa-session": "5.8.1",
     "koa-static": "4.0.2",
-    "koa-views": "6.1.4",
     "node-fs": "0.1.7",
     "passport": "0.4.0",
     "redis": "2.8.0",

--- a/test/core/test-params.js
+++ b/test/core/test-params.js
@@ -161,21 +161,18 @@ describe('Ravel', () => {
   describe('#_loadParameters()', () => {
     it('should allow users to specify Ravel config parameters via a .ravelrc.json config file', (done) => {
       conf = {
-        'koa view engine': 'ejs',
-        'redis port': 6379
+        'redis port': 1234
       };
       // can't use extension on mock because mockery only works with exact matches
       mockery.registerMock(upath.join(Ravel.cwd, '.ravelrc'), conf);
       Ravel[coreSymbols.loadParameters]();
-      expect(Ravel.get('koa view engine')).to.equal(conf['koa view engine']);
       expect(Ravel.get('redis port')).to.equal(conf['redis port']);
       done();
     });
 
     it('should should support searching for .ravelrc.json files in any parent directory of app.cwd', (done) => {
       conf = {
-        'koa view engine': 'ejs',
-        'redis port': 6379
+        'redis port': 1234
       };
       let parent = Ravel.cwd.split(upath.sep).slice(0, -1).join(upath.sep);
       const root = (os.platform() === 'win32') ? process.cwd().split(upath.sep)[0] : upath.sep;
@@ -185,15 +182,13 @@ describe('Ravel', () => {
       mockery.registerMock(joined, conf);
       Ravel[coreSymbols.loadParameters]();
       const msg = `Failed to find .ravelrc in ${joined}`;
-      expect(Ravel.get('koa view engine'), msg).to.equal(conf['koa view engine']);
       expect(Ravel.get('redis port'), msg).to.equal(conf['redis port']);
       done();
     });
 
     it('should should support searching for .ravelrc.json files in any parent directory of app.cwd, including root', (done) => {
       conf = {
-        'koa view engine': 'ejs',
-        'redis port': 6379
+        'redis port': 1234
       };
       const root = (os.platform() === 'win32') ? process.cwd().split(upath.sep)[0] : upath.sep;
       // can't use extension on mock because mockery only works with exact matches
@@ -201,19 +196,16 @@ describe('Ravel', () => {
       mockery.registerMock(upath.join(root, '.ravelrc'), conf);
       Ravel[coreSymbols.loadParameters]();
       const msg = `Failed to find .ravelrc in ${joined}`;
-      expect(Ravel.get('koa view engine'), msg).to.equal(conf['koa view engine']);
       expect(Ravel.get('redis port'), msg).to.equal(conf['redis port']);
       done();
     });
 
     it('should allow users to specify Ravel config parameters via a .ravelrc config file and parse it to JSON', (done) => {
       conf = {
-        'koa view engine': 'ejs',
-        'redis port': 6379
+        'redis port': 1234
       };
       mockery.registerMock(upath.join(Ravel.cwd, '.ravelrc'), JSON.stringify(conf));
       Ravel[coreSymbols.loadParameters]();
-      expect(Ravel.get('koa view engine')).to.equal(conf['koa view engine']);
       expect(Ravel.get('redis port')).to.equal(conf['redis port']);
       done();
     });
@@ -255,22 +247,19 @@ describe('Ravel', () => {
 
     it('should not override parameters set programmatically via Ravel.set', (done) => {
       conf = {
-        'koa view engine': 'ejs',
-        'redis port': 6379
+        'redis port': 1234
       };
       mockery.registerMock(upath.join(Ravel.cwd, '.ravelrc'), conf);
 
       Ravel.set('redis port', 6380);
       Ravel[coreSymbols.loadParameters]();
-      expect(Ravel.get('koa view engine')).to.equal(conf['koa view engine']);
       expect(Ravel.get('redis port')).to.equal(6380);
       done();
     });
 
     it('should throw a Ravel.ApplicationError.IllegalValue if an unregistered paramter is specified in the config file', (done) => {
       conf = {
-        'koa view engine': 'ejs',
-        'redis port': 6379
+        'redis port': 1234
       };
       conf[Math.random().toString()] = false;
       mockery.registerMock(upath.join(Ravel.cwd, '.ravelrc'), conf);

--- a/test/ravel/test-ravel-lifecycle.js
+++ b/test/ravel/test-ravel-lifecycle.js
@@ -168,8 +168,6 @@ describe('Ravel lifeycle test', () => {
   describe('#init()', () => {
     it('should initialize a koa server with appropriate middleware and parameters', async () => {
       app.set('koa public directory', 'public');
-      app.set('koa view engine', 'ejs');
-      app.set('koa view directory', 'views');
 
       let useSpy;
       const koaAppMock = class Moa extends require('koa') {
@@ -188,10 +186,6 @@ describe('Ravel lifeycle test', () => {
       const staticSpy = sinon.stub().returns(staticMiddleware);
       mockery.registerMock('koa-static', staticSpy);
 
-      const views = async function (ctx, next) { await next(); };
-      const viewSpy = sinon.stub().returns(views);
-      mockery.registerMock('koa-views', viewSpy);
-
       const favicon = async function (ctx, next) { await next(); };
       const faviconSpy = sinon.stub().returns(favicon);
       mockery.registerMock('koa-favicon', faviconSpy);
@@ -208,8 +202,6 @@ describe('Ravel lifeycle test', () => {
       expect(useSpy).to.have.been.calledWith(gzip);
       expect(staticSpy).to.have.been.calledWith(upath.join(app.cwd, app.get('koa public directory')));
       expect(useSpy).to.have.been.calledWith(staticMiddleware);
-      expect(viewSpy).to.have.been.calledWith(upath.join(app.cwd, app.get('koa view directory')));
-      expect(useSpy).to.have.been.calledWith(views);
       expect(faviconSpy).to.have.been.calledWith(upath.join(app.cwd, app.get('koa favicon path')));
       expect(useSpy).to.have.been.calledWith(favicon);
       expect(app.initialized).to.be.ok;


### PR DESCRIPTION
The library doesn't work properly anyway, and no one is using this feature. The correct way to render views should be to bring in the templating library of your choice, rather than "augmenting" `ctx` with random functionality (and bringing in an extra, unnecessary library).