### PR TITLE
Adding renaming support to @autoinject

### DIFF
--- a/documentation.yml
+++ b/documentation.yml
@@ -1,6 +1,7 @@
 name: Ravel API
-version: 1.0.0-rc.2
+version: 1.0.0-rc.3
 versions:
+  - 1.0.0-rc.3
   - 1.0.0-rc.2
   - 1.0.0-rc.1
   - 0.25.0

--- a/jest/core/decorators/autoinject.test.js
+++ b/jest/core/decorators/autoinject.test.js
@@ -12,7 +12,10 @@ describe('Ravel', () => {
       @autoinject('test1', 'test2')
       class Stub1 {
       }
-      expect(Metadata.getClassMetaValue(Stub1.prototype, '@autoinject', 'dependencies')).toEqual(['test1', 'test2']);
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@autoinject', 'dependencies')).toEqual({
+        'test1': 'test1',
+        'test2': 'test2'
+      });
     });
 
     it('should be able to be used more than once on the same class', () => {
@@ -20,12 +23,36 @@ describe('Ravel', () => {
       @autoinject('test3')
       class Stub1 {
       }
-      expect(Metadata.getClassMetaValue(Stub1.prototype, '@autoinject', 'dependencies')).toEqual(['test1', 'test2', 'test3']);
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@autoinject', 'dependencies')).toEqual({
+        'test1': 'test1',
+        'test2': 'test2',
+        'test3': 'test3'
+      });
+    });
+
+    it('should facilitate module renaming', () => {
+      @autoinject('test1', {'test2': 'mytest'})
+      @autoinject('test3')
+      class Stub1 {
+      }
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@autoinject', 'dependencies')).toEqual({
+        'test1': 'test1',
+        'test2': 'mytest',
+        'test3': 'test3'
+      });
     });
 
     it('should throw an $err.IllegalValue if a non-string type is passed to @autoinject', () => {
       const test = () => {
-        @autoinject([])
+        @autoinject(true)
+        class Stub {} // eslint-disable-line no-unused-vars
+      };
+      expect(test).toThrow($err.IllegalValue);
+    });
+
+    it('should throw an $err.IllegalValue if a non-string type is passed to @autoinject within an object', () => {
+      const test = () => {
+        @autoinject({'one': true})
         class Stub {} // eslint-disable-line no-unused-vars
       };
       expect(test).toThrow($err.IllegalValue);

--- a/jest/core/injector.test.js
+++ b/jest/core/injector.test.js
@@ -101,13 +101,13 @@ describe('Ravel', () => {
         jest.doMock('moment', () => stubMoment, {virtual: true});
 
         @Module('stub')
-        @autoinject('moment')
+        @autoinject({'moment': 'myMoment'})
         class Stub {
         }
         app.load(Stub);
         await app.init();
-        expect(typeof app.module('stub').moment).toBe('object');
-        expect(app.module('stub').moment).toBe(stubMoment);
+        expect(typeof app.module('stub').myMoment).toBe('object');
+        expect(app.module('stub').myMoment).toBe(stubMoment);
       });
 
       it('should throw an error when attempting to auto-inject an npm dependency with an error in it', async () => {
@@ -131,7 +131,7 @@ describe('Ravel', () => {
         await expect(app.init()).rejects.toThrow(app.$err.NotFound);
       });
 
-      it('should allow mixing @inject and @autinject', async () => {
+      it('should allow mixing @inject and @autoinject', async () => {
         @Module('stub1')
         class Stub1 {
           method () {}

--- a/lib/core/decorators/autoinject.js
+++ b/lib/core/decorators/autoinject.js
@@ -8,8 +8,9 @@ const Metadata = require('../../util/meta');
  * `Resources` and `Routes`.
  * Extremely similar to [@inject](#inject), but will automatmically
  * assign the injected components to values on the current scope,
- * based on name, after construction. This means that these values
- * will not be available in the construtor.
+ * based on name, after construction (this means that these values
+ * will not be available in the construtor). Injected modules can be
+ * locally renamed by supplying an alias.
  *
  * This decorator simply annotates the class with modules which
  * should be injected when Ravel initializes. See `util/injector`
@@ -23,10 +24,10 @@ const Metadata = require('../../util/meta');
  * const Module = require('ravel').Module;
  *
  * // &#64;@Module('mymodule')
- * // &#64;autoinject('path', 'fs', 'custom-module')
+ * // &#64;autoinject('path', {'fs': 'myfs'}, 'custom-module')
  * class MyModule {
  *   constructor () {
- *     // this.fs, this.path and this['custom-module']
+ *     // this.myfs, this.path and this['custom-module']
  *     // are not available in the constructor, and will
  *     // will be populated after construction time.
  *     // If you set any properties on this with identical
@@ -34,7 +35,7 @@ const Metadata = require('../../util/meta');
  *   }
  *
  *   aMethod() {
- *     // can access this.fs, this.path or this['custom-module']
+ *     // can access this.myfs, this.path or this['custom-module']
  *   }
  *
  *   // &#64;postinject
@@ -51,13 +52,20 @@ const autoinject = function (...rest) {
     if (rest.length === 0) {
       throw new $err.NotFound(`Empty @autoinject supplied on ${typeof target}`);
     }
+    const toInject = Object.assign({}, Metadata.getClassMetaValue(target.prototype, '@autoinject', 'dependencies', {}));
     for (const elem of rest) {
-      if (typeof elem !== 'string') {
-        throw new $err.IllegalValue('Values supplied to @inject decorator must be strings.');
+      if (typeof elem === 'string') {
+        toInject[elem] = elem;
+      } else if (typeof elem === 'object') {
+        if (Object.values(elem).filter(v => typeof v !== 'string').length > 0) {
+          throw new $err.IllegalValue('Values supplied to @autoinject decorator within objects must be strings.');
+        }
+        Object.assign(toInject, elem);
+      } else {
+        throw new $err.IllegalValue('Values supplied to @autoinject decorator must be strings or objects.');
       }
     }
-    Metadata.putClassMeta(target.prototype, '@autoinject', 'dependencies',
-      rest.concat(Metadata.getClassMetaValue(target.prototype, '@autoinject', 'dependencies', [])));
+    Metadata.putClassMeta(target.prototype, '@autoinject', 'dependencies', toInject);
   };
 };
 

--- a/lib/core/injector.js
+++ b/lib/core/injector.js
@@ -43,9 +43,7 @@ class Injector {
    * @private
    */
   getAutoinjectedDependencies (DIClass) {
-    return [].concat(
-      Metadata.getClassMetaValue(DIClass.prototype, '@autoinject', 'dependencies', [])
-    );
+    return Object.assign({}, Metadata.getClassMetaValue(DIClass.prototype, '@autoinject', 'dependencies', {}));
   }
 
   /**
@@ -115,8 +113,8 @@ class Injector {
     const instance = new DIClass(...args);
     // then do @autoinject
     const requestedAutoinjectionModules = this.getAutoinjectedDependencies(DIClass);
-    for (const auto of requestedAutoinjectionModules) {
-      instance[auto] = this.getModule(moduleMap, auto);
+    for (const auto of Object.keys(requestedAutoinjectionModules)) {
+      instance[requestedAutoinjectionModules[auto]] = this.getModule(moduleMap, auto);
     }
     return instance;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ravel",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "author": "Sean McIntyre <s.mcintyre@xverba.ca>",
   "description": "Ravel Rapid Application Development Framework",
   "engines": {


### PR DESCRIPTION
Allow for the following sort of thing:

```
@autoinject('test1', {'test2': 'mytest'})
@autoinject('test3')
@Module('mymodule')
class Stub {
}
```