### PR TITLE
Feature/271 - session store changed param support

### DIFF
--- a/lib/util/redis_session_store.js
+++ b/lib/util/redis_session_store.js
@@ -60,16 +60,23 @@ class RedisSessionStore extends EventEmitter {
     });
   }
 
-  set (sid, sess, ttl) {
+  set (sid, sess, ttl, opts = { changed: true }) {
     return new Promise((resolve, reject) => {
       if (typeof ttl === 'number') {
         ttl = Math.ceil(ttl / 1000);
       }
-      const jsess = JSON.stringify(sess);
-      if (ttl !== undefined) {
-        this[sRavelInstance].$kvstore.setex(sid, ttl, jsess, finishBasicPromise(resolve, reject));
+      if (opts.changed) {
+        const jsess = JSON.stringify(sess);
+        if (ttl !== undefined) {
+          this[sRavelInstance].$kvstore.setex(sid, ttl, jsess, finishBasicPromise(resolve, reject));
+        } else {
+          this[sRavelInstance].$kvstore.set(sid, jsess, finishBasicPromise(resolve, reject));
+        }
+      } else if (ttl !== undefined) {
+        this[sRavelInstance].$kvstore.expire(sid, ttl, finishBasicPromise(resolve, reject));
       } else {
-        this[sRavelInstance].$kvstore.set(sid, jsess, finishBasicPromise(resolve, reject));
+        // Nothing to be done
+        resolve();
       }
     });
   }


### PR DESCRIPTION
Adds support for the changed param passed in by koa-session so that unchanged sessions only update expiry.

I didn't use the rolling parameter because koa-session doesn't actually use that at all when using the renew option, so I didn't see a universal way to make use of the rolling parameter.