### PR TITLE
Feature/253 parameterized middleware

### DIFF
--- a/jest/core/decorators/create_middleware_decorator.test.js
+++ b/jest/core/decorators/create_middleware_decorator.test.js
@@ -1,0 +1,87 @@
+describe('Ravel', () => {
+  const $err = require('../../../lib/util/application_error');
+  const Metadata = require('../../../lib/util/meta');
+  let createMiddlewareDecorator;
+
+  beforeEach(() => {
+    createMiddlewareDecorator = require('../../../lib/ravel').Resource.createMiddlewareDecorator;
+  });
+
+  describe('createMiddlewareDecorator()', () => {
+    it('should create a named middleware decorator that attaches the named midleware def to decorated classes', () => {
+      const test1Decorator = createMiddlewareDecorator('test1');
+      @test1Decorator()
+      class Stub1 {
+      }
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@middlewareDecorators', 'middleware')).toEqual([{
+        name: 'test1',
+        args: []
+      }]);
+    });
+
+    it('should create a named middleware decorator that accepts params', () => {
+      const myMiddlewareDecorator = createMiddlewareDecorator('my-middleware');
+      @myMiddlewareDecorator('val1', { otherParam: true })
+      class Stub1 {
+      }
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@middlewareDecorators', 'middleware')).toEqual([{
+        name: 'my-middleware',
+        args: ['val1', { otherParam: true }]
+      }]);
+    });
+
+    it('should throw an $err.IllegalValue if a non-string type is passed to createMiddlewareDecorator', () => {
+      const test = () => {
+        createMiddlewareDecorator([]);
+      };
+      expect(test).toThrow($err.IllegalValue);
+    });
+
+    it('should decorate a class with method-specific middleware if a custom middleware decorator is applied to a method', () => {
+      const myMiddlewareDecorator = createMiddlewareDecorator('my-middleware');
+      class Stub1 {
+        @myMiddlewareDecorator('val1', { otherParam: true })
+        get () {
+        }
+      }
+      expect(Metadata.getMethodMetaValue(Stub1.prototype, 'get', '@middlewareDecorators', 'middleware')).toEqual([{
+        name: 'my-middleware',
+        args: ['val1', { otherParam: true }]
+      }]);
+    });
+
+    it('should decorate a class with multiple middleware info in order of decorator usage', () => {
+      const myMiddlewareDecorator1 = createMiddlewareDecorator('my-middleware1');
+      const myMiddlewareDecorator2 = createMiddlewareDecorator('my-middleware2');
+      @myMiddlewareDecorator1('val1', { otherParam1: true })
+      @myMiddlewareDecorator2('val2', { otherParam2: true })
+      class Stub1 {
+      }
+      expect(Metadata.getClassMetaValue(Stub1.prototype, '@middlewareDecorators', 'middleware')).toEqual([{
+        name: 'my-middleware1',
+        args: ['val1', { otherParam1: true }]
+      }, {
+        name: 'my-middleware2',
+        args: ['val2', { otherParam2: true }]
+      }]);
+    });
+
+    it('should decorate a class method with multiple middleware info in order of decorator usage', () => {
+      const myMiddlewareDecorator1 = createMiddlewareDecorator('my-middleware1');
+      const myMiddlewareDecorator2 = createMiddlewareDecorator('my-middleware2');
+      class Stub1 {
+        @myMiddlewareDecorator1('val1', { otherParam1: true })
+        @myMiddlewareDecorator2('val2', { otherParam2: true })
+        get () {
+        }
+      }
+      expect(Metadata.getMethodMetaValue(Stub1.prototype, 'get', '@middlewareDecorators', 'middleware')).toEqual([{
+        name: 'my-middleware1',
+        args: ['val1', { otherParam1: true }]
+      }, {
+        name: 'my-middleware2',
+        args: ['val2', { otherParam2: true }]
+      }]);
+    });
+  });
+});

--- a/jest/core/decorators/middleware.test.js
+++ b/jest/core/decorators/middleware.test.js
@@ -22,7 +22,21 @@ describe('Ravel', () => {
         @middleware('some-middleware')
         async someMiddleware () {}
       }
-      expect(typeof Metadata.getClassMetaValue(Stub1.prototype, '@middleware', 'some-middleware')).toBe('function');
+      const metavalue = Metadata.getClassMetaValue(Stub1.prototype, '@middleware', 'some-middleware');
+      expect(typeof metavalue).toBe('object');
+      expect(typeof metavalue.fn).toBe('function');
+    });
+
+    it('should register a Module method as injectable middleware with options', () => {
+      @Ravel.Module('test')
+      class Stub1 {
+        @middleware('some-middleware', { someOption: true })
+        async someMiddleware () {}
+      }
+      const metavalue = Metadata.getClassMetaValue(Stub1.prototype, '@middleware', 'some-middleware');
+      expect(typeof metavalue).toBe('object');
+      expect(typeof metavalue.fn).toBe('function');
+      expect(metavalue.options).toEqual({ someOption: true });
     });
 
     it('should throw a DuplicateEntry error when middleware is registered with the same name as a module', async () => {

--- a/jest/integration/ravel-middleware-decorators.test.js
+++ b/jest/integration/ravel-middleware-decorators.test.js
@@ -1,0 +1,56 @@
+describe('Ravel end-to-end middleware decorators test', () => {
+  let app;
+
+  describe('basic application server consisting of routes', () => {
+    beforeEach(async () => {
+      const Ravel = require('../../lib/ravel');
+      // stub Routes (miscellaneous routes, such as templated HTML content)
+      const middleware = Ravel.Module.middleware;
+      const mapping = Ravel.Routes.mapping;
+      const someMiddleware = Ravel.Routes.createMiddlewareDecorator('some-middleware');
+      const capitalize = Ravel.Routes.createMiddlewareDecorator('capitalize');
+
+      @Ravel.Module('testm')
+      class TestModule {
+        @middleware('some-middleware')
+        async someMiddleware (ctx, next) {
+          ctx.body = 'Hello';
+          await next();
+        }
+
+        @middleware('capitalize', { acceptsParams: true })
+        capitalizeMiddleware ({ shouldCapitalize }) {
+          return async (ctx, next) => {
+            if (shouldCapitalize === 'true') {
+              ctx.body = ctx.body.toUpperCase();
+            }
+            await next();
+          };
+        }
+      }
+
+      @Ravel.Routes('/api/routes')
+      class TestRoutes {
+        @someMiddleware()
+        @capitalize({ shouldCapitalize: 'true' })
+        @mapping(Ravel.Routes.GET, '/')
+        getHandler (ctx) {
+          ctx.body += ' World!';
+        }
+      }
+
+      app = new Ravel();
+      app.set('log level', app.$log.INFO);
+      app.set('keygrip keys', ['mysecret']);
+
+      app.load(TestModule, TestRoutes);
+      await app.init();
+    });
+
+    it('createMiddlewareDecorator should attach the named @middleware to the route handler', () => {
+      return request(app.callback)
+        .get('/api/routes')
+        .expect(200, 'HELLO World!');
+    });
+  });
+});

--- a/lib/core/decorators/create_middleware_decorator.js
+++ b/lib/core/decorators/create_middleware_decorator.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const $err = require('../../util/application_error');
+const Metadata = require('../../util/meta');
+
+/**
+ * A factory for creating custom decorators that use associated middleware. The returned
+ * decorator can be used on classes or methods and allow passing custom params to the
+ * associated middleware before the decorated object is run.
+ *
+ * A decorator can be used multiple times on the same decorated object, which will add
+ * multiple calls to the associated middleware using the passed in params.
+ *
+ * @param {string} middlewareName - The name of an associated middleware module to lookup and use.
+ * @example
+ * // Note: decorator works the same way on Routes or Resource classes
+ *
+ * const Module = require('ravel').Module;
+ * const middleware = Module.middleware;
+ *
+ * // &#64;Module('mymodule')
+ * class MyModule {
+ *   // &#64;middleware('my-middleware', { acceptsParams: true })
+ *   doSomethingMiddleware (...params) {
+ *     // ...params refer to the params passed to the associated decorator
+ *     return async doSomething (ctx, next) {
+ *       //...
+ *     };
+ *   }
+ * }
+ *
+ * //...
+ * const Resource = require('ravel').Resource;
+ * const myMiddleWare = Resource.createMiddlewareDecorator('my-middleware');
+ * // &#64;Resource('/')
+ * class MyResource {
+ *   // &#64;myMiddleWare('val1', { someParamInputs: true })
+ *   async getAll () {
+ *     // doSomething('val', { someParamInputs: true}) will be called before this
+ *     //...
+ *   }
+ * }
+ */
+function createMiddlewareDecorator (middlewareName) {
+  if (typeof middlewareName !== 'string' || middlewareName.length === 0) {
+    throw new $err.IllegalValue('Middleware decorator names must be strings used with @middleware.');
+  }
+
+  // return the decorator that takes params for the middleware
+  return function (...args) {
+    return function (target, key) {
+      if (key === undefined) {
+        // get the existing custom decorator defs array for the class, or create one if it doesn't exist
+        let customDecoratorDefs = Metadata.getClassMetaValue(target.prototype, '@middlewareDecorators', 'middleware',
+          null);
+        if (customDecoratorDefs === null) {
+          customDecoratorDefs = [];
+          Metadata.putClassMeta(target.prototype, '@middlewareDecorators', 'middleware', customDecoratorDefs);
+        }
+        // add another middleware usage to the list based on the passed in arguments
+        // use reverse order so decorators are run in top down declared order
+        customDecoratorDefs.unshift({
+          name: middlewareName,
+          args: args
+        });
+      } else {
+        // get the existing custom decorator defs array for the method, or create one if it doesn't exist
+        let customDecoratorDefs = Metadata.getMethodMetaValue(target, key, '@middlewareDecorators', 'middleware', null);
+        if (customDecoratorDefs === null) {
+          customDecoratorDefs = [];
+          Metadata.putMethodMeta(target, key, '@middlewareDecorators', 'middleware', customDecoratorDefs);
+        }
+        // add another middleware usage to the list based on the passed in arguments
+        // use reverse order so decorators are run in top down declared order
+        customDecoratorDefs.unshift({
+          name: middlewareName,
+          args: args
+        });
+      }
+    };
+  };
+}
+
+/*!
+ * Export the `@middleware` decorator factory
+ */
+module.exports = createMiddlewareDecorator;

--- a/lib/core/decorators/middleware.js
+++ b/lib/core/decorators/middleware.js
@@ -3,12 +3,15 @@ const Metadata = require('../../util/meta');
 /**
  * Method-level decorator for `Module` methods, so that
  * they are registered as middleware which can be injected
- * automatically by `@before`.
+ * automatically by `@before` or decorators created with
+ * `createMiddlewareDecorator`.
  * Made available through the Module class.
  * See [`Module`](#module) for more information.
  *
- * @param {string} name - The injection name this middlware will be made available under.
- * @param {object?} options - Ravel options used to configure the middleware.
+ * @param {string} name - The injection name this middleware will be made available under.
+ * @param {object?} options - Ravel options used to configure the middleware. If the
+ *   option 'acceptsParams' is set to true then the middleware function will be treated as
+ *   a factory method when used with a custom middleware decorator.
  * @example
  * const Module = require('ravel').Module;
  * const middleware = Module.middleware;
@@ -25,6 +28,31 @@ const Metadata = require('../../util/meta');
  * // &#64;Resource('/')
  * class MyResource {
  *   // &#64;before('my-middleware')
+ *   async getAll () {
+ *     //...
+ *   }
+ * }
+ *
+ * @example
+ * const Module = require('ravel').Module;
+ * const middleware = Module.middleware;
+ * // &#64;Module('mymodule')
+ * class MyModule {
+ *   // &#64;middleware('my-middleware', { acceptsParams: true })
+ *   doSomethingMiddleware (param1) {
+ *     // called once per usage in a route
+ *     return async function doSomething (ctx, next) {
+ *       // normal async middleware ...
+ *     };
+ *   }
+ * }
+ * //...
+ * const Resource = require('ravel').Resource;
+ * const myMiddleware = Resource.createMiddlewareDecorator('my-middleware');
+ *
+ * // &#64;Resource('/')
+ * class MyResource {
+ *   // &#64;myMiddleware('foo')
  *   async getAll () {
  *     //...
  *   }

--- a/lib/core/decorators/middleware.js
+++ b/lib/core/decorators/middleware.js
@@ -8,6 +8,7 @@ const Metadata = require('../../util/meta');
  * See [`Module`](#module) for more information.
  *
  * @param {string} name - The injection name this middlware will be made available under.
+ * @param {object?} options - Ravel options used to configure the middleware.
  * @example
  * const Module = require('ravel').Module;
  * const middleware = Module.middleware;
@@ -31,9 +32,9 @@ const Metadata = require('../../util/meta');
  *
  * @private
  */
-function middleware (name) {
+function middleware (name, options) {
   return function (target, key, descriptor) {
-    Metadata.putClassMeta(target, '@middleware', name, descriptor.value);
+    Metadata.putClassMeta(target, '@middleware', name, { fn: descriptor.value, options: options });
   };
 }
 

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -57,7 +57,11 @@ async function initModule (ravelInstance) {
           `Unable to register @middleware with name ${m}, which conflicts with an existing Module name`);
       } else {
         ravelInstance.$log.info(`Registering middleware with name ${m}`);
-        ravelInstance[symbols.middleware][m] = middleware[m].bind(self);
+        ravelInstance[symbols.middleware][m] = {
+          scope: self,
+          fn: middleware[m].fn,
+          options: middleware[m].options
+        };
       }
     }
   });

--- a/lib/core/resource.js
+++ b/lib/core/resource.js
@@ -158,6 +158,15 @@ module.exports.Resource.mapping = function () {
 module.exports.Resource.before = require('./decorators/before');
 
 /**
+ * A factory for creating custom decorators that use associated middleware
+ * on `Routes` and `Resource` classes.
+ *
+ * See [`createMiddlewareDecorator`](#createMiddlewareDecorator) for more information.
+ * @memberof Resource
+ */
+module.exports.Resource.createMiddlewareDecorator = require('./decorators/create_middleware_decorator');
+
+/**
  * The `@transaction` decorator for `Routes` and `Resource` classes.
  *
  * See [`transaction`](#transaction) for more information.

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -98,12 +98,47 @@ function buildRoute (ravelInstance, routes, koaRouter, methodName, meta) {
       // middleware def is a function so use it as is
       middleware.push(moduleMiddlewareDef);
     } else if (typeof moduleMiddlewareDef === 'object') {
-      // middleware may have options
+      // make sure middleware doesn't expect params
       if (moduleMiddlewareDef.options && moduleMiddlewareDef.options.acceptsParams) {
-        // TODO get params to pass in
-        const params = [];
-        middleware.push(moduleMiddlewareDef.fn.apply(moduleMiddlewareDef.scope, params));
+        throw new this.$err.General(`Middleware ${m} expects params, so it cannot be used with @before.`);
+      }
+      middleware.push(moduleMiddlewareDef.fn.bind(moduleMiddlewareDef.scope));
+    }
+  }
+
+  // apply class-level custom middleware decorators, if any
+  let middlewareUseDefn = [].concat(Metadata.getClassMetaValue(routes, '@middlewareDecorators', 'middleware', []));
+
+  // then method-level custom middleware decorators, if any
+  middlewareUseDefn = middlewareUseDefn.concat(
+    Metadata.getMethodMetaValue(routes, methodName, '@middlewareDecorators', 'middleware', []));
+
+  for (let i = 0; i < middlewareUseDefn.length; i++) {
+    const mUseDefn = middlewareUseDefn[i];
+    const moduleMiddlewareDef = ravelInstance[symbols.injector].getModule(routes, mUseDefn.name);
+    if (moduleMiddlewareDef == null) {
+      throw new this.$err.General(`Middleware decorator request for middleware '${mUseDefn.name}' does not exist`);
+    }
+
+    if (typeof moduleMiddlewareDef === 'function') {
+      // since the middleware def doesn't accept params, make sure we didn't pass any
+      if (mUseDefn.args && mUseDefn.args.length > 0) {
+        throw new this.$err.General(
+          `Middleware decorator ${mUseDefn.name} passed in parameters, but the middleware does not support them`);
+      }
+      // middleware def is a function so use it as is
+      middleware.push(moduleMiddlewareDef);
+    } else if (typeof moduleMiddlewareDef === 'object') {
+      // make sure middleware doesn't expect params
+      if (moduleMiddlewareDef.options && moduleMiddlewareDef.options.acceptsParams) {
+        const inited = moduleMiddlewareDef.fn.apply(moduleMiddlewareDef.scope, mUseDefn.args);
+        middleware.push(inited);
+        // middleware.push(moduleMiddlewareDef.fn.apply(moduleMiddlewareDef.scope, mUseDefn.args));
       } else {
+        if (mUseDefn.args && mUseDefn.args.length > 0) {
+          throw new this.$err.General(
+            `Middleware decorator ${mUseDefn.name} passed in parameters, but the middleware does not support them`);
+        }
         middleware.push(moduleMiddlewareDef.fn.bind(moduleMiddlewareDef.scope));
       }
     }
@@ -347,6 +382,15 @@ module.exports.Routes.mapping = require('./decorators/mapping');
  * @memberof Routes
  */
 module.exports.Routes.before = require('./decorators/before');
+
+/**
+ * A factory for creating custom decorators that use associated middleware
+ * on `Routes` and `Resource` classes.
+ *
+ * See [`createMiddlewareDecorator`](#createMiddlewareDecorator) for more information.
+ * @memberof Routes
+ */
+module.exports.Routes.createMiddlewareDecorator = require('./decorators/create_middleware_decorator');
 
 /**
  * The `@transaction` decorator for `Routes` and `Resource` classes.

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -93,7 +93,20 @@ function buildRoute (ravelInstance, routes, koaRouter, methodName, meta) {
 
   for (let i = 0; i < toInject.length; i++) {
     const m = toInject[i];
-    middleware.push(ravelInstance[symbols.injector].getModule(routes, m));
+    const moduleMiddlewareDef = ravelInstance[symbols.injector].getModule(routes, m);
+    if (typeof moduleMiddlewareDef === 'function') {
+      // middleware def is a function so use it as is
+      middleware.push(moduleMiddlewareDef);
+    } else if (typeof moduleMiddlewareDef === 'object') {
+      // middleware may have options
+      if (moduleMiddlewareDef.options && moduleMiddlewareDef.options.acceptsParams) {
+        // TODO get params to pass in
+        const params = [];
+        middleware.push(moduleMiddlewareDef.fn.apply(moduleMiddlewareDef.scope, params));
+      } else {
+        middleware.push(moduleMiddlewareDef.fn.bind(moduleMiddlewareDef.scope));
+      }
+    }
   }
 
   // then cache middleware, if present


### PR DESCRIPTION
Here's a first attempt at a solution for #253 with fully parameterized middleware decorators.

This adds a new 'options' param to the middleware decorator so users can pass the option `{ "acceptsParams": true }` and treat the middleware function as a factory method that will take params. This is an opt-in feature, so middleware functions without the option will act as they did before.
 
Then there's a new `Resource.createMiddlewareDecorator(middlewareName)` function that allows users to create a named decorator that references DI middleware the same way as the before decorator. The creation of the decorator is abstracted away from users so it can be changed whenever the proposals are finalized.
The custom decorators simply attach the passed in params into the resource/route so they can be pulled out during route init to generate appropriate middleware from the associated named middleware. Each decorated class/method adds another usage def to an array of middleware usage defs so that multiple decorators can be used on the same method. 

Middleware is run in the order that it's defined on the class/method (ie top down)
```javascript
@myMiddlewareFirst('val1')
@myMiddlewareSecond('val2')
async myResourceThird (ctxt, next) {
}
```
and I've added it after the `@before` middleware, although we could fix up the `@before` middleware to use the same paths as the custom decorators in order to eliminate some code and to clear up any potential for confusing order of operations.

Basically an example would look like this
```javascript
const Module = require('ravel').Module;
const middleware = Module.middleware;
@Module('mymodule')
class PermissionsModule {
  // method marked with 'acceptsParams' so it's treated as a factory method
  @middleware('needs-permissions, { acceptsParams: true })
  needsPermissionsMiddleware (resId, perms) {
    // called once per usage in a route
    // NOTE: could use other DI modules here like normal, allowing custom decorators the appearance of working with normal DI stuff
    return async function needsPermissions(ctx, next) {
      // normal async middleware ...
    };
  }
}
//...
const Resource = require('ravel').Resource;
// create a decorator that will call named middleware from above
const needsPermissions = Resource.createMiddlewareDecorator('needs-permissions');

@Resource('/project')
class ProjectResource {
  @needsPermissions('/project', 'write')  // requires owner permissions
  @needsPermissions('/dataset/:datasetId', 'write')  // requires permissions to modify datasets
  async post () {
    //...
  }
}
```

Let me know what you think.