### PR TITLE
Enabling parameterized middleware by extending @before

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ class MyMiddleware {
 
   // this middleware is also available elsewhere by name,
   // but is a factory that can receive two arguments
-  @middleware('another-middleware', true)
+  @middleware('another-middleware', { factory: true })
   anotherMiddlewareFactory (arg1, arg2) {
     return async (ctx, next) {
       await next();

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ module.exports = Cities;
 
 ### Middleware
 
-`Ravel` middleware takes the form of an `async function` and is defined within `Modules`:
+`Ravel` middleware takes the form of an `async function` and is defined within `Modules`, either directly or via a factory pattern:
 
 *modules/cities.js*
 ```js
@@ -159,6 +159,15 @@ class MyMiddleware {
     // ... do something before the next middleware runs
     await next();
     // ... do something after the next middlware runs
+  }
+
+  // this middleware is also available elsewhere by name,
+  // but is a factory that can receive two arguments
+  @middleware('another-middleware', true)
+  anotherMiddlewareFactory (arg1, arg2) {
+    return async (ctx, next) {
+      await next();
+    }
   }
 }
 ```
@@ -186,6 +195,12 @@ class ExampleRoutes {
     // ctx is just a koa context! Have a look at the koa docs to see what methods and properties are available.
     ctx.body = '<!DOCTYPE html><html><body>Hello World!</body></html>';
     ctx.status = 200;
+  }
+
+  @mapping(Routes.GET, 'log')
+  @before('another-middleware', 1, 2, 'custom-middleware') // use @before to instantiate middleware which accepts arguments, alongside middleware which doesn't.
+  async logHandler (ctx) {
+    // ...
   }
 }
 
@@ -222,6 +237,7 @@ class CitiesResource {
   }
 
   @before('custom-middleware') // using @before at the method level decorates this method with middleware
+  @before('another-middleware', 1, 2) // use @before multiple times for clarity, if desired
   async get (ctx) { // get routes automatically receive an endpoint of /cities/:id (in this case).
     ctx.body = await this.cities.getCity(ctx.params.id);
   }

--- a/jest/core/decorators/middleware.test.js
+++ b/jest/core/decorators/middleware.test.js
@@ -31,7 +31,7 @@ describe('Ravel', () => {
     it('should register a Module method as injectable middleware factory', () => {
       @Ravel.Module('test')
       class Stub1 {
-        @middleware('some-middleware', true)
+        @middleware('some-middleware', { factory: true })
         someMiddlewareFactory (one, two) {
           return async function () {};
         }

--- a/jest/core/decorators/middleware.test.js
+++ b/jest/core/decorators/middleware.test.js
@@ -22,7 +22,25 @@ describe('Ravel', () => {
         @middleware('some-middleware')
         async someMiddleware () {}
       }
-      expect(typeof Metadata.getClassMetaValue(Stub1.prototype, '@middleware', 'some-middleware')).toBe('function');
+      const middlewareMeta = Metadata.getClassMetaValue(Stub1.prototype, '@middleware', 'some-middleware');
+      expect(typeof middlewareMeta).toBe('object');
+      expect(typeof middlewareMeta.fn).toBe('function');
+      expect(middlewareMeta.isFactory).toBeFalsy();
+    });
+
+    it('should register a Module method as injectable middleware factory', () => {
+      @Ravel.Module('test')
+      class Stub1 {
+        @middleware('some-middleware', true)
+        someMiddlewareFactory (one, two) {
+          return async function () {};
+        }
+      }
+      const middlewareMeta = Metadata.getClassMetaValue(Stub1.prototype, '@middleware', 'some-middleware');
+      expect(typeof middlewareMeta).toBe('object');
+      expect(typeof middlewareMeta.fn).toBe('function');
+      expect(middlewareMeta.fn.length).toBe(2);
+      expect(middlewareMeta.isFactory).toBeTruthy();
     });
 
     it('should throw a DuplicateEntry error when middleware is registered with the same name as a module', async () => {

--- a/jest/core/routes.test.js
+++ b/jest/core/routes.test.js
@@ -332,5 +332,26 @@ describe('Ravel', () => {
       expect(response.statusCode).toBe(200);
       expect(response.body).toEqual({id: 3});
     });
+
+    it('should throw a Ravel.$err.IllegalValueError error when clients attempt to use a middleware factory with fewer than the required number of arguments', async () => {
+      @Ravel.Module('/')
+      class TestModule {
+        @Ravel.Module.middleware('middleware1')
+        middlewareFactory (one, two) {
+          return async function () {};
+        }
+      }
+      @Ravel.Routes('/')
+      class TestRoutes {
+        @Ravel.Routes.mapping(Ravel.Routes.GET, '/test')
+        @Ravel.Routes.before('middleware1', 'arg1')
+        pathHandler (ctx) {
+          ctx.status = 200;
+        }
+      }
+      app.load(TestModule, TestRoutes);
+      expect.assertions(1);
+      await expect(app.init()).rejects.toThrow(app.$err.IllegalValueError);
+    });
   });
 });

--- a/jest/core/routes.test.js
+++ b/jest/core/routes.test.js
@@ -336,7 +336,7 @@ describe('Ravel', () => {
     it('should throw a Ravel.$err.IllegalValueError error when clients attempt to use a middleware factory with fewer than the required number of arguments', async () => {
       @Ravel.Module('/')
       class TestModule {
-        @Ravel.Module.middleware('middleware1')
+        @Ravel.Module.middleware('middleware1', true)
         middlewareFactory (one, two) {
           return async function () {};
         }
@@ -350,7 +350,6 @@ describe('Ravel', () => {
         }
       }
       app.load(TestModule, TestRoutes);
-      expect.assertions(1);
       await expect(app.init()).rejects.toThrow(app.$err.IllegalValueError);
     });
   });

--- a/jest/core/routes.test.js
+++ b/jest/core/routes.test.js
@@ -336,7 +336,7 @@ describe('Ravel', () => {
     it('should throw a Ravel.$err.IllegalValueError error when clients attempt to use a middleware factory with fewer than the required number of arguments', async () => {
       @Ravel.Module('/')
       class TestModule {
-        @Ravel.Module.middleware('middleware1', true)
+        @Ravel.Module.middleware('middleware1', { factory: true })
         middlewareFactory (one, two) {
           return async function () {};
         }

--- a/jest/integration/ravel-middleware.test.js
+++ b/jest/integration/ravel-middleware.test.js
@@ -17,7 +17,7 @@ describe('Ravel end-to-end middleware test', () => {
           await next();
         }
 
-        @middleware('another-middleware', true)
+        @middleware('another-middleware', { factory: true })
         anotherMiddlewareFactory (word) {
           return async function (ctx, next) {
             ctx.body = word;

--- a/jest/integration/ravel-middleware.test.js
+++ b/jest/integration/ravel-middleware.test.js
@@ -16,13 +16,27 @@ describe('Ravel end-to-end middleware test', () => {
           ctx.body = 'Hello';
           await next();
         }
+
+        @middleware('another-middleware', true)
+        anotherMiddlewareFactory (word) {
+          return async function (ctx, next) {
+            ctx.body = word;
+            await next();
+          };
+        }
       }
 
       @Ravel.Routes('/api/routes')
       class TestRoutes {
         @pre('some-middleware')
-        @mapping(Ravel.Routes.GET, '/')
+        @mapping(Ravel.Routes.GET, '/some')
         getHandler (ctx) {
+          ctx.body += ' World!';
+        }
+
+        @pre('another-middleware', 'Goodbye')
+        @mapping(Ravel.Routes.GET, '/another')
+        anotherHandler (ctx) {
           ctx.body += ' World!';
         }
       }
@@ -37,8 +51,14 @@ describe('Ravel end-to-end middleware test', () => {
 
     it('@middleware should make a module method available as middleware for use with @before', () => {
       return request(app.callback)
-        .get('/api/routes')
+        .get('/api/routes/some')
         .expect(200, 'Hello World!');
+    });
+
+    it('@middleware should make a module factory method available as middleware for use with @before', () => {
+      return request(app.callback)
+        .get('/api/routes/another')
+        .expect(200, 'Goodbye World!');
     });
   });
 });

--- a/lib/core/decorators/middleware.js
+++ b/lib/core/decorators/middleware.js
@@ -7,7 +7,8 @@ const Metadata = require('../../util/meta');
  * Made available through the Module class.
  * See [`Module`](#module) for more information.
  *
- * @param {string} name - The injection name this middlware will be made available under.
+ * @param {string} name - The injection name this middleware will be made available under.
+ * @param {boolean} isFactory - Whether or not this is a middleware factory (a function that returns middleware).
  * @example
  * const Module = require('ravel').Module;
  * const middleware = Module.middleware;
@@ -29,11 +30,33 @@ const Metadata = require('../../util/meta');
  *   }
  * }
  *
+ * @example
+ * const Module = require('ravel').Module;
+ * const middleware = Module.middleware;
+ * // &#64;Module('mymodule')
+ * class MyModule {
+ *   // &#64;middleware('my-middleware', true)
+ *   doSomethingFactory (word, number) {
+ *     return async function (ctx, next) {
+ *       //...
+ *     };
+ *   }
+ * }
+ * //...
+ * const Resource = require('ravel').Resource;
+ * const before = Resource.before;
+ * // &#64;Resource('/')
+ * class MyResource {
+ *   // &#64;before('my-middleware', 'hello', 12)
+ *   async getAll () {
+ *     //...
+ *   }
+ * }
  * @private
  */
-function middleware (name) {
+function middleware (name, isFactory = false) {
   return function (target, key, descriptor) {
-    Metadata.putClassMeta(target, '@middleware', name, descriptor.value);
+    Metadata.putClassMeta(target, '@middleware', name, {fn: descriptor.value, isFactory: isFactory});
   };
 }
 

--- a/lib/core/decorators/middleware.js
+++ b/lib/core/decorators/middleware.js
@@ -8,7 +8,8 @@ const Metadata = require('../../util/meta');
  * See [`Module`](#module) for more information.
  *
  * @param {string} name - The injection name this middleware will be made available under.
- * @param {boolean} isFactory - Whether or not this is a middleware factory (a function that returns middleware).
+ * @param {Object} config - Configuration for this middleware definition.
+ * @param {boolean} config.factory - Whether or not this is a middleware factory (a function that returns middleware).
  * @example
  * const Module = require('ravel').Module;
  * const middleware = Module.middleware;
@@ -35,7 +36,7 @@ const Metadata = require('../../util/meta');
  * const middleware = Module.middleware;
  * // &#64;Module('mymodule')
  * class MyModule {
- *   // &#64;middleware('my-middleware', true)
+ *   // &#64;middleware('my-middleware', {factory: true})
  *   doSomethingFactory (word, number) {
  *     return async function (ctx, next) {
  *       //...
@@ -54,9 +55,9 @@ const Metadata = require('../../util/meta');
  * }
  * @private
  */
-function middleware (name, isFactory = false) {
+function middleware (name, config = {factory: false}) {
   return function (target, key, descriptor) {
-    Metadata.putClassMeta(target, '@middleware', name, {fn: descriptor.value, isFactory: isFactory});
+    Metadata.putClassMeta(target, '@middleware', name, {fn: descriptor.value, isFactory: config.factory});
   };
 }
 

--- a/lib/core/module.js
+++ b/lib/core/module.js
@@ -57,7 +57,8 @@ async function initModule (ravelInstance) {
           `Unable to register @middleware with name ${m}, which conflicts with an existing Module name`);
       } else {
         ravelInstance.$log.info(`Registering middleware with name ${m}`);
-        ravelInstance[symbols.middleware][m] = middleware[m].bind(self);
+        middleware[m].fn = middleware[m].fn.bind(self);
+        ravelInstance[symbols.middleware][m] = middleware[m];
       }
     }
   });

--- a/lib/core/routes.js
+++ b/lib/core/routes.js
@@ -93,7 +93,22 @@ function buildRoute (ravelInstance, routes, koaRouter, methodName, meta) {
 
   for (let i = 0; i < toInject.length; i++) {
     const m = toInject[i];
-    middleware.push(ravelInstance[symbols.injector].getModule(routes, m));
+    const middlewareFactory = ravelInstance[symbols.injector].getModule(routes, m);
+    let middlewareFn;
+    if (typeof middlewareFactory === 'object' && middlewareFactory.isFactory) {
+      if (i + middlewareFactory.fn.length >= toInject.length) {
+        throw new ravelInstance.$err.IllegalValueError(
+          `Middleware ${m} requires ${middlewareFactory.fn.length} arguments for instantiation.
+           Specify with @before('${m}', arg1, arg2, ...)`);
+      }
+      middlewareFn = middlewareFactory.fn(...toInject.slice(i + 1, i + 1 + middlewareFactory.fn.length));
+      i += middlewareFactory.fn.length; // skip ahead
+    } else if (typeof middlewareFactory === 'object') {
+      middlewareFn = middlewareFactory.fn;
+    } else {
+      middlewareFn = middlewareFactory; // for reverse compatibility
+    }
+    middleware.push(middlewareFn);
   }
 
   // then cache middleware, if present


### PR DESCRIPTION
Fixes #253 

This approach extends `@before` to allow for the specification of arguments to middleware factory methods.

Middleware can now be declared as factories accepting arguments:

```js
@Module('mymodule')
class MyModule {
  @middleware('my-middleware', {factory: true}) // true indicates this is a Factory, false by default
  doSomethingFactory (arg1, arg2) {
    return async function (ctx, next) {
      //...
    }
  }
}

@Resource('/')
class MyResource {
  // here we can supply arguments to 'my-middleware' via @before
  @before('my-middleware', 'hello', 12)
  async getAll () {
    //...
  }
}
```

`@before` can either be used more than once for clarity:

```js
@before('my-middleware', 'hello', 12)
@before('another-middleware')
async getAll () {
  //...
}
```

or equivalently all in one line, with `my-middleware` consuming as many arguments as it needs for instantiation based on its factory definition:

```js
@before('my-middleware', 'hello', 12, 'another-middleware')
async getAll () {
  //...
}
```