### PR TITLE
Deliberately registering an undefined default value for a param should throw, as this is likely to be user error.

### DIFF
--- a/jest/core/params.test.js
+++ b/jest/core/params.test.js
@@ -12,6 +12,15 @@ describe('Ravel', () => {
     app.set('log level', app.$log.NONE);
   });
 
+  describe('#registerParamter()', () => {
+    it('should throw if a client attempts to register a parameter with a deliberately undefined default value', () => {
+      expect(() => {
+        const undefinedEnvironmentVariable = undefined;
+        app.registerParameter('my param', true, undefinedEnvironmentVariable);
+      }).toThrow(app.$err.IllegalValue);
+    });
+  });
+
   describe('#set()', () => {
     it('should allow clients to set the value of a parameter', async () => {
       app.registerParameter('test param', false);

--- a/lib/core/params.js
+++ b/lib/core/params.js
@@ -125,6 +125,7 @@ module.exports = function (Ravel) {
     }
   };
 
+  /* eslint-disable jsdoc/check-param-names */
   /**
    * Register an application parameter.
    *
@@ -132,14 +133,17 @@ module.exports = function (Ravel) {
    * @param {boolean} required - True, iff the parameter is required. False otherwise.
    * @param {(any | undefined)} defaultValue - The default value for the parameter.
    */
-  Ravel.prototype.registerParameter = function (key, required, defaultValue) {
+  Ravel.prototype.registerParameter = function (key, required) {
     this[symbols.knownParameters][key] = {
       required: required
     };
-    if (defaultValue !== undefined) {
-      defaults[key] = JSON.parse(JSON.stringify(defaultValue));
+    if (arguments.length === 3 && arguments[2] !== undefined) {
+      defaults[key] = JSON.parse(JSON.stringify(arguments[2]));
+    } else if (arguments.length === 3 && arguments[2] === undefined) {
+      throw new this.$err.IllegalValue(`Undefined default value supplied for parameter "${key}"`);
     }
   };
+  /* eslint-enable jsdoc/check-param-names */
 
   /**
    * Set the value of an application parameter.


### PR DESCRIPTION
Fixes #290 